### PR TITLE
docs: add netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "yarn install --frozen-lockfile && yarn build && cd docs && yarn install --frozen-lockfile && yarn build"
+  publish = "docs/build"


### PR DESCRIPTION
I've created a netlify deployment for ui-widgets [here](https://dhis2-ui-widgets.netlify.com/) - note that since there's nothing to build or host on the master branch this will fail.  The contents of netlify.toml will need to be updated with the appropriate build step and publish directory when there's something to build.