### PR TITLE
fix: styled-jsx needs to be a peer dep for all libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,19 +54,20 @@
         "husky": "^1.0.1",
         "react-dev-utils": "^8.0.0",
         "storybook-addon-jsx": "^7.0.0",
-        "typeface-roboto": "^0.0.54"
+        "typeface-roboto": "^0.0.54",
+        "styled-jsx": "^3.2.1"
     },
     "peerDependencies": {
         "@dhis2/app-runtime": "1.1.0",
         "prop-types": "^15",
         "react": "^16.8",
-        "react-dom": "^16.8"
+        "react-dom": "^16.8",
+        "styled-jsx": "^3.2.1"
     },
     "dependencies": {
         "@dhis2/d2-i18n": "1.0.4",
         "@dhis2/ui-core": "2.0.2",
-        "classnames": "^2.2.6",
-        "styled-jsx": "^3.2.1"
+        "classnames": "^2.2.6"
     },
     "files": [
         "./build"


### PR DESCRIPTION
Because of https://github.com/zeit/styled-jsx/issues/64 styled-jsx needs
to be a peer dependency for all libraries, and pulled in once by the
App, so the instance can be shared.

Related to: https://github.com/dhis2/ui-core/pull/204