### PR TITLE
fix: don't break the page structure while loading data for the headerbar

### DIFF
--- a/src/HeaderBar/Notifications.js
+++ b/src/HeaderBar/Notifications.js
@@ -20,7 +20,6 @@ export const Notifications = ({ interpretations, messages }) => (
 
         <style jsx>{`
             div {
-                margin-left: auto;
                 user-select: none;
                 display: flex;
                 flex-direction: row;

--- a/src/HeaderBar/index.js
+++ b/src/HeaderBar/index.js
@@ -34,27 +34,35 @@ export const HeaderBar = ({ appName, className }) => {
         },
     })
 
-    if (loading) return <span>...</span>
-
     if (error) return <span>{`ERROR: ${error.message}`}</span>
 
-    const locale = data.user.settings.keyUiLocale || 'en'
-    i18n.changeLanguage(locale)
+    if (!loading) {
+        // TODO: This will run every render which is probably wrong!  Also, setting the global locale shouldn't be done in the headerbar
+        const locale = data.user.settings.keyUiLocale || 'en'
+        i18n.changeLanguage(locale)
+    }
 
     return (
         <header className={className}>
             <Logo />
 
-            <Title app={appName} instance={data.systemInfo.systemName} />
-
-            <Notifications
-                interpretations={data.notifications.unreadInterpretations}
-                messages={data.notifications.unreadMessageConversations}
-            />
-
-            <Apps apps={data.apps.modules} />
-
-            <Profile user={data.user} />
+            {!loading && (
+                <>
+                    <Title
+                        app={appName}
+                        instance={data.systemInfo.systemName}
+                    />
+                    <div className="rightControlSpacer" />
+                    <Notifications
+                        interpretations={
+                            data.notifications.unreadInterpretations
+                        }
+                        messages={data.notifications.unreadMessageConversations}
+                    />
+                    <Apps apps={data.apps.modules} />
+                    <Profile user={data.user} />
+                </>
+            )}
 
             <style jsx>{`
                 header {
@@ -66,6 +74,9 @@ export const HeaderBar = ({ appName, className }) => {
                     height: 48px;
                     border-bottom: 1px solid rgba(32, 32, 32, 0.15);
                     color: ${colors.white};
+                }
+                .rightControlSpacer {
+                    margin-left: auto;
                 }
             `}</style>
         </header>

--- a/stories/HeaderBar.stories.js
+++ b/stories/HeaderBar.stories.js
@@ -74,8 +74,14 @@ const customData = {
     },
 }
 
-storiesOf('HeaderBar', module).add('Default', () => (
-    <CustomDataProvider data={customData}>
-        <HeaderBar appName="Example!" />
-    </CustomDataProvider>
-))
+storiesOf('HeaderBar', module)
+    .add('Default', () => (
+        <CustomDataProvider data={customData}>
+            <HeaderBar appName="Example!" />
+        </CustomDataProvider>
+    ))
+    .add('Loading...', () => (
+        <CustomDataProvider options={{ loadForever: true }}>
+            <HeaderBar appName="Example!" />
+        </CustomDataProvider>
+    ))


### PR DESCRIPTION
Requires dhis2/app-runtime#11 to support loading states in Storybook.

Instead of rendering the disruptive and ugly `...` paceholder while waiting for initial data to load, this keeps the macro structure of the headerbar in place but omits the data-dependent content.  It will make page loads less jerky.  We may want to indicate the loading state in some subtle way as well (@cooper-joe) but that can be a separate change.

<img width="1792" alt="Screenshot 2019-05-27 12 20 02" src="https://user-images.githubusercontent.com/947888/58413814-fa490b80-8079-11e9-8807-dcb5cb91fb33.png">

I also added a loading state story to the storybook.
