### PR TITLE
feat: organisation unit tree

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,7 +2,7 @@ const isTesting = 'STORYBOOK_TESTING' in process.env
 
 module.exports = {
     stories: isTesting
-        ? ['../src/__e2e__/*.stories.js']
+        ? ['../src/__e2e__/**/*.stories.js']
         : ['../src/__demo__/*.stories.js'],
 
     addons: [

--- a/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000000.json
+++ b/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000000.json
@@ -1,0 +1,21 @@
+{
+    "path": "/A0000000000",
+    "displayName": "Org Unit 1",
+    "children": [
+        {
+            "id": "A0000000001",
+            "displayName": "Org Unit 2",
+            "children": [{ "id": "A0000000003" }, { "id": "A0000000004" }]
+        },
+        {
+            "id": "A0000000002",
+            "displayName": "Org Unit 3",
+            "children": []
+        },
+        {
+            "id": "A0000000006",
+            "displayName": "Org Unit 7",
+            "children": []
+        }
+    ]
+}

--- a/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000001.json
+++ b/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000001.json
@@ -1,0 +1,16 @@
+{
+    "path": "/A0000000000/A0000000001",
+    "displayName": "Org Unit 2",
+    "children": [
+        {
+            "id": "A0000000003",
+            "displayName": "Org Unit 4",
+            "children": []
+        },
+        {
+            "id": "A0000000004",
+            "displayName": "Org Unit 5",
+            "children": []
+        }
+    ]
+}

--- a/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000002.json
+++ b/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000002.json
@@ -1,0 +1,5 @@
+{
+    "path": "/A0000000000/A0000000002",
+    "displayName": "Org Unit 3",
+    "children": []
+}

--- a/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000003.json
+++ b/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000003.json
@@ -1,0 +1,5 @@
+{
+    "path": "/A0000000000/A0000000001/A0000000003",
+    "displayName": "Org Unit 4",
+    "children": []
+}

--- a/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000004.json
+++ b/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000004.json
@@ -1,0 +1,5 @@
+{
+    "path": "/A0000000000/A0000000001/A0000000004",
+    "displayName": "Org Unit 5",
+    "children": []
+}

--- a/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000005.json
+++ b/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000005.json
@@ -1,0 +1,5 @@
+{
+    "path": "/A0000000000/A0000000005",
+    "displayName": "Org Unit 6",
+    "children": []
+}

--- a/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000006.json
+++ b/cypress/fixtures/OrganisationUnitTree/organisationUnits/A0000000006.json
@@ -1,0 +1,5 @@
+{
+    "path": "/A0000000000/A0000000006",
+    "displayName": "Org Unit 7",
+    "children": []
+}

--- a/cypress/integration/OrganisationUnitTree/children_as_child_nodes.feature
+++ b/cypress/integration/OrganisationUnitTree/children_as_child_nodes.feature
@@ -1,0 +1,6 @@
+Feature: Children of a node are rendered as a child node
+
+    Scenario: A unit has some children
+        Given an OrganisationUnitTree with children is rendered
+        And the node is open
+        Then its children are nodes inside the unit's node

--- a/cypress/integration/OrganisationUnitTree/children_as_child_nodes/index.js
+++ b/cypress/integration/OrganisationUnitTree/children_as_child_nodes/index.js
@@ -1,0 +1,30 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an OrganisationUnitTree with children is rendered', () => {
+    cy.visitStory('OrganisationUnitTree', 'Closed with children')
+})
+
+Given('the node is open', () => {
+    cy.get(
+        '[data-test="dhis2-uiwidgets-orgunittree"] > [data-test="dhis2-uiwidgets-orgunittree-node"]'
+    ).as('rootUnit')
+
+    cy.get('@rootUnit').openOrgUnitNode()
+})
+
+Then("its children are nodes inside the unit's node", () => {
+    cy.get('@rootUnit')
+        .find(
+            '> [data-test="dhis2-uiwidgets-orgunittree-node-content"] > [data-test="dhis2-uiwidgets-orgunittree-node-leaves"]'
+        )
+        .children()
+        .then(children => console.log('children', children) || children)
+        .should('have.length', 3)
+        .and(children =>
+            children.each((_, child) => {
+                const $child = Cypress.$(child)
+                const dataTest = $child.data('test')
+                expect(dataTest).to.equal('dhis2-uiwidgets-orgunittree-node')
+            })
+        )
+})

--- a/cypress/integration/OrganisationUnitTree/displaying_loading_error.feature
+++ b/cypress/integration/OrganisationUnitTree/displaying_loading_error.feature
@@ -1,0 +1,24 @@
+Feature: When loading children fails a loading error should be shown
+
+    Due to the asynchronous nature of the tree, loading children
+    can fail at any given time. An appropriate error message should
+    be displayed when this happens
+
+    The error does not show automatically until a node's
+    children should be displayed.
+    This behavior can be changed to expand the node immediately
+    when the loading process fails.
+
+    Scenario: Loading the children of the root unit fails and error should not be auto expanded
+        Given loading errors do not display automatically and loading A0000000001's children will fail
+        And the OrganisationUnitTree is closed
+        When the A0000000000 path is opened
+        Then no error message is shown
+        When the A0000000000 -> A0000000001 path is opened
+        Then an appropriate error message is shown
+
+    Scenario: Loading the children of the root unit fails and error should be auto expanded
+        Given loading errors display automatically and loading A0000000001's children will fail
+        And the OrganisationUnitTree is closed
+        When the A0000000000 path is opened
+        Then an appropriate error message is shown

--- a/cypress/integration/OrganisationUnitTree/displaying_loading_error/index.js
+++ b/cypress/integration/OrganisationUnitTree/displaying_loading_error/index.js
@@ -1,0 +1,46 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given(
+    "loading errors do not display automatically and loading A0000000001's children will fail",
+    () => {
+        cy.visitStory('OrganisationUnitTree', 'A0000000001 loading error')
+    }
+)
+
+Given(
+    "loading errors display automatically and loading A0000000001's children will fail",
+    () => {
+        cy.visitStory(
+            'OrganisationUnitTree',
+            'A0000000001 loading error autoexpand'
+        )
+    }
+)
+
+Given('the OrganisationUnitTree is closed', () => {
+    cy.get(
+        '[data-test="dhis2-uiwidgets-orgunittree"] > [data-test="dhis2-uiwidgets-orgunittree-node"]'
+    )
+        .as('rootNode')
+        .shouldBeAClosedNode()
+})
+
+When('the A0000000000 path is opened', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').openOrgUnitNode()
+})
+
+When('the A0000000000 -> A0000000001 path is opened', () => {
+    cy.getOrgUnitByLabel('Org Unit 2').openOrgUnitNode()
+})
+
+Then('no error message is shown', () => {
+    cy.getOrgUnitByLabel('Org Unit 2')
+        .find('[data-test="dhis2-uiwidgets-orgunittree-error"]')
+        .should('not.exist')
+})
+
+Then('an appropriate error message is shown', () => {
+    cy.getOrgUnitByLabel('Org Unit 2')
+        .find('[data-test="dhis2-uiwidgets-orgunittree-error"]')
+        .should('contain', 'Could not load children')
+})

--- a/cypress/integration/OrganisationUnitTree/force_reload.feature
+++ b/cypress/integration/OrganisationUnitTree/force_reload.feature
@@ -1,0 +1,7 @@
+Feature: The whole organisation unit tree can be reloaded
+
+    Scenario: The whole tree is reloaded while being opened
+        Given a OrganisationUnitTree with three levels is rendered
+        And the two parent levels are opened
+        When the tree is being force reloaded and the loading process has finished
+        Then all three levels are visible again

--- a/cypress/integration/OrganisationUnitTree/force_reload/index.js
+++ b/cypress/integration/OrganisationUnitTree/force_reload/index.js
@@ -1,0 +1,38 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a OrganisationUnitTree with three levels is rendered', () => {
+    cy.visitStory('OrganisationUnitTree', 'Force reloading')
+})
+
+Given('the two parent levels are opened', () => {
+    cy.getOrgUnitByLabel('Org Unit 1')
+        .as('rootNode')
+        .openOrgUnitNode()
+
+    cy.getOrgUnitByLabel('Org Unit 2').openOrgUnitNode()
+
+    cy.get('@rootNode')
+        .find(
+            '[data-test="dhis2-uiwidgets-orgunittree-node"] [data-test="dhis2-uiwidgets-orgunittree-node"]'
+        )
+        .should('exist')
+})
+
+When(
+    'the tree is being force reloaded and the loading process has finished',
+    () => {
+        cy.get('[data-test="reload-all"]').click()
+    }
+)
+
+Then('all three levels are visible again', () => {
+    cy.get('@rootNode')
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node"]')
+        .should('exist')
+
+    cy.get('@rootNode')
+        .find(
+            '[data-test="dhis2-uiwidgets-orgunittree-node"] [data-test="dhis2-uiwidgets-orgunittree-node"]'
+        )
+        .should('exist')
+})

--- a/cypress/integration/OrganisationUnitTree/highlight.feature
+++ b/cypress/integration/OrganisationUnitTree/highlight.feature
@@ -1,0 +1,5 @@
+Feature: Units can be highlighted
+
+    Scenario: The root unit is highlighted
+        Given a OrganisationUnitTree with a highlighted root unit is rendered
+        Then root unit has the highlighted styles

--- a/cypress/integration/OrganisationUnitTree/highlight/index.js
+++ b/cypress/integration/OrganisationUnitTree/highlight/index.js
@@ -1,0 +1,11 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a OrganisationUnitTree with a highlighted root unit is rendered', () => {
+    cy.visitStory('OrganisationUnitTree', 'Root highlighted')
+})
+
+Then('root unit has the highlighted styles', () => {
+    cy.getOrgUnitByLabel('Org Unit 1')
+        .find('.highlighted')
+        .should('exist')
+})

--- a/cypress/integration/OrganisationUnitTree/initially_expanded.feature
+++ b/cypress/integration/OrganisationUnitTree/initially_expanded.feature
@@ -1,0 +1,11 @@
+Feature: When provided some paths of the OrganisationUnitTree are expanded initially
+
+    Scenario: No initially expanded paths are provided
+        Given a OrganisationUnitTree with children and no paths in the initiallyExpanded prop is rendered
+        Then the root unit is closed
+
+    # The given step is really long.. but I don't know how to split it while being able to test/prepare
+    # that with cypress
+    Scenario: The first unit on the second level is provided as initially expanded path
+        Given a OrganisationUnitTree with children and the path of the first unit on the second level in the initiallyExpanded prop is rendered
+        Then the root unit is opened

--- a/cypress/integration/OrganisationUnitTree/initially_expanded/index.js
+++ b/cypress/integration/OrganisationUnitTree/initially_expanded/index.js
@@ -1,0 +1,23 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given(
+    'a OrganisationUnitTree with children and no paths in the initiallyExpanded prop is rendered',
+    () => {
+        cy.visitStory('OrganisationUnitTree', 'No initially expanded paths')
+    }
+)
+
+Given(
+    'a OrganisationUnitTree with children and the path of the first unit on the second level in the initiallyExpanded prop is rendered',
+    () => {
+        cy.visitStory('OrganisationUnitTree', 'Initially expanded paths')
+    }
+)
+
+Then('the root unit is closed', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').shouldBeAClosedNode()
+})
+
+Then('the root unit is opened', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').shouldBeAnOrgUnitNode()
+})

--- a/cypress/integration/OrganisationUnitTree/loading_state.feature
+++ b/cypress/integration/OrganisationUnitTree/loading_state.feature
@@ -1,0 +1,7 @@
+Feature: When a unit is loading its children then there is a loading indicator
+
+    Scenario: The first second-level unit is loading its children
+        Given a OrganisationUnitTree with two levels is rendered
+        And the root level is closed
+        When the root level is opened
+        Then there is a loading indicator rendered on the first child of the second level

--- a/cypress/integration/OrganisationUnitTree/loading_state/index.js
+++ b/cypress/integration/OrganisationUnitTree/loading_state/index.js
@@ -1,0 +1,28 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a OrganisationUnitTree with two levels is rendered', () => {
+    cy.visitStory('OrganisationUnitTree', 'A0000000001 loading')
+})
+
+Given('the root level is closed', () => {
+    cy.getOrgUnitByLabel('Org Unit 1')
+        .as('rootUnit')
+        .shouldBeAClosedNode()
+})
+
+When('the root level is opened', () => {
+    cy.get('@rootUnit').openOrgUnitNode()
+})
+
+Then(
+    'there is a loading indicator rendered on the first child of the second level',
+    () => {
+        cy.getOrgUnitByLabel('Org Unit 2')
+            .find('[data-test="dhis2-uicore-circularloader"]')
+            .should('exist')
+
+        cy.getOrgUnitByLabel('Org Unit 2')
+            .find('[data-test="dhis2-uiwidgets-orgunittree-node-leaves"]:empty')
+            .should('exist')
+    }
+)

--- a/cypress/integration/OrganisationUnitTree/multi_selection.feature
+++ b/cypress/integration/OrganisationUnitTree/multi_selection.feature
@@ -1,0 +1,31 @@
+Feature: When not limited any amount of units can be selected
+
+    Scenario: The user selects a unit when no other unit is selected
+        Given an OrganisationUnitTree with two levels is rendered
+        And no unit is selected
+        When the user selects a unit
+        Then a unit is selected
+
+    Scenario: The user selects a unit when a parent unit is not selected
+        Given an OrganisationUnitTree with two levels is rendered
+        And the root level unit is opened
+        When the user selects the first unit on the second level
+        Then the unit on the second level is selected
+        Then the unit on the first level is marked as selected intermediately
+
+    Scenario: The user selects a unit which is selected intermediately
+        Given an OrganisationUnitTree with two levels is rendered
+        And the root level unit is opened
+        And the first unit on the second level is selected
+        When the user selects the root level
+        Then the root unit is marked as selected
+
+    Scenario: The user selects a unit when another unit on the same level is selected
+        Given an OrganisationUnitTree with two levels is rendered
+        And the root level unit is opened
+        And the first unit on the second level unit is opened
+        And the second level has two units
+        And the first unit on the second level is selected
+        When the user selects the second unit on the second level
+        Then the first unit is selected
+        Then the second unit is selected

--- a/cypress/integration/OrganisationUnitTree/multi_selection/index.js
+++ b/cypress/integration/OrganisationUnitTree/multi_selection/index.js
@@ -1,0 +1,94 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an OrganisationUnitTree with two levels is rendered', () => {
+    cy.visitStory('OrganisationUnitTree', 'Multiple selection')
+})
+
+Given('no unit is selected', () => {
+    cy.window().then(win => {
+        expect(win.selection).to.eql([])
+    })
+})
+
+Given('the root level unit is opened', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').openOrgUnitNode(true)
+})
+
+Given('the first unit on the second level is selected', () => {
+    cy.getOrgUnitByLabel('Org Unit 2').toggleOrgUnitNodeSelection(true)
+})
+
+Given('the first unit on the second level unit is opened', () => {
+    cy.getOrgUnitByLabel('Org Unit 2').openOrgUnitNode(true)
+})
+
+Given('the second level has two units', () => {
+    cy.getOrgUnitByLabel('Org Unit 2')
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node-leaves"]')
+        .first()
+        .children()
+        .filter((index, child) =>
+            Cypress.$(child).is(
+                '[data-test="dhis2-uiwidgets-orgunittree-node"]'
+            )
+        )
+        .should('have.length', 2)
+})
+
+When('the user selects a unit', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').toggleOrgUnitNodeSelection(true)
+})
+
+When('the user selects the first unit on the second level', () => {
+    cy.getOrgUnitByLabel('Org Unit 2').toggleOrgUnitNodeSelection(true)
+})
+
+When('the user selects the root level', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').toggleOrgUnitNodeSelection(true)
+})
+
+When('the user selects the second unit on the second level', () => {
+    cy.getOrgUnitByLabel('Org Unit 3').toggleOrgUnitNodeSelection(true)
+})
+
+Then('a unit is selected', () => {
+    cy.window().then(win => {
+        expect(win.selection).to.eql(['/A0000000000'])
+    })
+})
+
+Then('the unit on the second level is selected', () => {
+    cy.window().then(win => {
+        expect(win.selection).to.eql(['/A0000000000/A0000000001'])
+    })
+})
+
+Then('the unit on the first level is marked as selected intermediately', () => {
+    cy.getOrgUnitByLabel('Org Unit 1')
+        .find(
+            '[data-test="dhis2-uiwidgets-orgunittree-node-label"] [data-test="dhis2-uicore-checkbox"] input'
+        )
+        .then($input => {
+            expect($input[0].indeterminate).to.be.true
+        })
+})
+
+Then('the root unit is marked as selected', () => {
+    cy.window().then(win => {
+        expect(win.selection.includes('/A0000000000')).to.be.true
+    })
+})
+
+Then('the first unit is selected', () => {
+    cy.window().then(win => {
+        expect(win.selection.includes('/A0000000000/A0000000001')).to.be.true
+        expect(win.selection).to.have.length(2)
+    })
+})
+
+Then('the second unit is selected', () => {
+    cy.window().then(win => {
+        expect(win.selection.includes('/A0000000000/A0000000002')).to.be.true
+        expect(win.selection).to.have.length(2)
+    })
+})

--- a/cypress/integration/OrganisationUnitTree/no_selection.feature
+++ b/cypress/integration/OrganisationUnitTree/no_selection.feature
@@ -1,0 +1,13 @@
+Feature: Selection can be disabled entirely in the OrganisationUnitTree
+
+    Scenario: The user clicks on a level of the disabled OrganisationUnitTree with the second level collapsed
+        Given a disabled, collapsed OrganisationUnitTree with two levels is rendered
+        When the root node is clicked
+        Then the root node remains unselected
+        But the second level is expanded
+
+    Scenario: The user clicks on a level of the disabled OrganisationUnitTree with the second level expanded
+        Given a disabled OrganisationUnitTree with two levels is rendered with the second level is expanded
+        When the root node is clicked
+        Then the root node remains unselected
+        But the second level is collapsed

--- a/cypress/integration/OrganisationUnitTree/no_selection/index.js
+++ b/cypress/integration/OrganisationUnitTree/no_selection/index.js
@@ -1,0 +1,43 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given(
+    'a disabled, collapsed OrganisationUnitTree with two levels is rendered',
+    () => {
+        cy.visitStory('OrganisationUnitTree', 'No selection closed')
+    }
+)
+
+Given(
+    'a disabled OrganisationUnitTree with two levels is rendered with the second level is expanded',
+    () => {
+        cy.visitStory('OrganisationUnitTree', 'No selection root opened')
+    }
+)
+
+When('the root node is clicked', () => {
+    cy.getOrgUnitByLabel('Org Unit 1')
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node-label"]')
+        .first()
+        .trigger('click')
+})
+
+Then('the root node remains unselected', () => {
+    cy.getOrgUnitByLabel('Org Unit 1')
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node-label"]')
+        .first()
+        .as('rootLabel')
+        .find('.checked')
+        .should('not.exist')
+
+    cy.get('@rootLabel')
+        .find('input')
+        .should('not.exist')
+})
+
+Then('the second level is expanded', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').shouldBeAnOpenNode()
+})
+
+Then('the second level is collapsed', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').shouldBeAClosedNode()
+})

--- a/cypress/integration/OrganisationUnitTree/path_based_filtering.feature
+++ b/cypress/integration/OrganisationUnitTree/path_based_filtering.feature
@@ -1,0 +1,24 @@
+Feature: The OrganisationUnitTree can be filtered by paths
+
+    Scenario: The org unit tree is filtered by a three-level-deep path
+        Given a unfiltered OrganisationUnitTree with a depth of 3 levels is rendered
+        And the second level contains two nodes
+        And all parent levels are open
+        And a filter containing the first child of the first second level is provided
+        Then the root level is visible
+        And the first node on the second level is visible
+        And the first child node of the first node on the second level is visible
+        And all other nodes are not rendered
+
+    Scenario: The org unit tree is filtered by a three-level- and a two-level-deep path
+        Given a filtered OrganisationUnitTree with a depth of 3 levels is rendered
+        And the second level contains two nodes
+        And the second level nodes each have a child node
+        And all parent levels are open
+        And a filter containing the first child of the second level is provided
+        And a filter containing the second child of the first level is provided
+        Then the root level is visible
+        And the first node on the second level is visible
+        And the first child node of the first node on the second level is visible
+        And the second node on the first level is visible
+        And all other nodes are not rendered

--- a/cypress/integration/OrganisationUnitTree/path_based_filtering/index.js
+++ b/cypress/integration/OrganisationUnitTree/path_based_filtering/index.js
@@ -1,0 +1,95 @@
+import { Before, Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Before(() => {
+    cy.wrap([]).as('displayedUnits')
+})
+
+const addDisplayedUnit = id => {
+    cy.get('@displayedUnits').then(displayedUnits => {
+        cy.wrap([...displayedUnits, id]).as('displayedUnits')
+    })
+}
+
+Given(
+    'a unfiltered OrganisationUnitTree with a depth of 3 levels is rendered',
+    () => {
+        cy.visitStory('OrganisationUnitTree', 'Filtered by 3-level-path')
+    }
+)
+
+Given(
+    'a filtered OrganisationUnitTree with a depth of 3 levels is rendered',
+    () => {
+        cy.visitStory(
+            'OrganisationUnitTree',
+            'Filtered by 3-level-path and 2-level-path'
+        )
+    }
+)
+
+/**
+ * left empty intentionally
+ * ========================
+ * Step is necessary to make the feature file understandable
+ * Required states are prepared by the story
+ */
+Given('the second level contains two nodes', () => {})
+Given('all parent levels are open', () => {})
+Given(
+    'a filter containing the first child of the first second level is provided',
+    () => {}
+)
+Given('the second level nodes each have a child node', () => {})
+Given(
+    'a filter containing the first child of the second level is provided',
+    () => {}
+)
+Given(
+    'a filter containing the second child of the first level is provided',
+    () => {}
+)
+
+Then('the root level is visible', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').should('exist')
+
+    addDisplayedUnit('A0000000000')
+})
+
+Then('the first node on the second level is visible', () => {
+    cy.getOrgUnitByLabel('Org Unit 2').should('exist')
+
+    addDisplayedUnit('A0000000001')
+})
+
+Then(
+    'the first child node of the first node on the second level is visible',
+    () => {
+        cy.getOrgUnitByLabel('Org Unit 4').should('exist')
+
+        addDisplayedUnit('A0000000003')
+    }
+)
+
+Then('the second node on the first level is visible', () => {
+    cy.getOrgUnitByLabel('Org Unit 3').should('exist')
+
+    addDisplayedUnit('A0000000002')
+})
+
+Then('all other nodes are not rendered', async () => {
+    cy.get('@displayedUnits').then(displayedUnits => {
+        cy.window().then(win => {
+            const excludedUnitNumbers = Object.keys(win.dataProviderData)
+                .map(key => key.replace('organisationUnits/', ''))
+                .filter(unit => !displayedUnits.includes(unit))
+                .map(id => parseInt(id.replace(/^.*(\d)$/, '$1'), 10) + 1)
+
+            excludedUnitNumbers.forEach(number => {
+                const label = `Org Unit ${number}`
+                cy.get(
+                    `[data-test="dhis2-uiwidgets-orgunittree-node-label"]:contains("${label}")`
+                ).should('not.exist')
+            })
+        })
+    })
+})

--- a/cypress/integration/OrganisationUnitTree/single_selection.feature
+++ b/cypress/integration/OrganisationUnitTree/single_selection.feature
@@ -1,0 +1,20 @@
+Feature: When specified only one unit can be selected
+
+    Scenario: The user selects a unit when no other unit is selected
+        Given an OrganisationUnitTree with two nodes is rendered
+        And no unit is selected
+        When the user selects the first unit
+        Then the first unit is selected
+
+    Scenario: The user select a unit when another unit is selected
+        Given an OrganisationUnitTree with two nodes is rendered
+        And the first unit has been selected
+        When the user selects the second unit
+        Then the first unit is not selected
+        Then the second unit is selected
+
+    Scenario: The user deselects a unit
+        Given an OrganisationUnitTree with two nodes is rendered
+        And the first unit has been selected
+        When the user deselects the first unit
+        Then no unit is selected

--- a/cypress/integration/OrganisationUnitTree/single_selection/index.js
+++ b/cypress/integration/OrganisationUnitTree/single_selection/index.js
@@ -1,0 +1,45 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an OrganisationUnitTree with two nodes is rendered', () => {
+    cy.visitStory('OrganisationUnitTree', 'Single selection')
+})
+
+Given('no unit is selected', () => {
+    cy.get('.checked').should('not.exist')
+})
+
+Given('the first unit has been selected', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').toggleOrgUnitNodeSelection(true, true)
+})
+
+When('the user selects the first unit', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').toggleOrgUnitNodeSelection(true, true)
+})
+
+When('the user selects the second unit', () => {
+    cy.getOrgUnitByLabel('Org Unit 2').toggleOrgUnitNodeSelection(true, true)
+})
+
+When('the user deselects the first unit', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').toggleOrgUnitNodeSelection(false, true)
+})
+
+Then('the first unit is selected', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').shouldBeASelectedOrgUnitNode(true)
+})
+
+Then('the first unit is not selected', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').shouldNotBeASelectedOrgUnitNode(true)
+})
+
+Then('the second unit is selected', () => {
+    cy.getOrgUnitByLabel('Org Unit 2').shouldBeASelectedOrgUnitNode(true)
+})
+
+Then('no unit is selected', () => {
+    cy.get('[data-test="dhis2-uiwidgets-orgunittree-node"]').then($nodes => {
+        $nodes.each((index, node) => {
+            cy.wrap(Cypress.$(node)).shouldNotBeASelectedOrgUnitNode()
+        })
+    })
+})

--- a/cypress/integration/OrganisationUnitTree/tree_api.feature
+++ b/cypress/integration/OrganisationUnitTree/tree_api.feature
@@ -1,0 +1,37 @@
+Feature: The OrganisationUnitTree offers props for its events
+
+    Scenario: The user selects a node
+        Given an OrganisationUnitTree is rendered
+        When a node gets selected
+        Then the onChange callback gets called
+        And the payload includes the path of the selected node
+        And the payload includes checked which is set to "true"
+        And the payload includes all selected nodes
+
+    Scenario: The user deselects a node
+        Given an OrganisationUnitTree is rendered
+        And a node has been selected
+        When a node gets deselected
+        Then the onChange callback gets called
+        And the payload includes the path of the selected node
+        And the payload includes checked which is set to "false"
+
+    Scenario: The user expands a node with children
+        Given a node with children is rendered
+        When the node is expanded
+        Then the onExpand callback gets called
+        And the payload includes the path of the expanded node
+
+    Scenario: The user collapses a node with children
+        Given a node with children is rendered
+        And the node has been expanded
+        When a node is collapsed
+        Then the onCollapse callback gets called
+        And the payload includes the path of the collapsed node
+
+    Scenario: Children of a node are done being loaded
+        Given a node with children is rendered
+        But the children haven't been loaded yet
+        When the children have been loaded
+        Then the onChildrenLoaded callback gets called
+        And the payload contains the loaded children's data

--- a/cypress/integration/OrganisationUnitTree/tree_api/index.js
+++ b/cypress/integration/OrganisationUnitTree/tree_api/index.js
@@ -1,0 +1,121 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+const expectStubPayloadToEqual = (stub, prop, expected) => {
+    const calls = stub.getCalls()
+    const { args } = calls[calls.length - 1]
+    const [payload] = args
+    expect(payload[prop]).to.eql(expected)
+}
+
+Given('an OrganisationUnitTree is rendered', () => {
+    cy.visitStory('OrganisationUnitTree', 'Events')
+    cy.getOrgUnitByLabel('Org Unit 1').shouldBeDoneLoading()
+})
+
+Given('a node has been selected', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').toggleOrgUnitNodeSelection(true)
+})
+
+Given('a node with children is rendered', () => {
+    cy.visitStory('OrganisationUnitTree', 'Events')
+})
+
+Given('the node has been expanded', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').openOrgUnitNode()
+})
+
+Given("the children haven't been loaded yet", () => {
+    cy.window().then(win => {
+        expect(win.onExpand).not.to.be.called
+    })
+})
+
+When('a node gets selected', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').toggleOrgUnitNodeSelection(true)
+})
+
+When('a node gets deselected', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').toggleOrgUnitNodeSelection(false)
+})
+
+When('the node is expanded', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').openOrgUnitNode()
+})
+
+When('a node is collapsed', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').closeOrgUnitNode()
+})
+
+When('the children have been loaded', () => {
+    cy.getOrgUnitByLabel('Org Unit 1').toggleOrgUnitNode(true)
+})
+
+Then('the onChange callback gets called', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.called
+    })
+})
+
+Then('the payload includes the path of the selected node', () => {
+    cy.window().then(win => {
+        expectStubPayloadToEqual(win.onChange, 'path', '/A0000000000')
+    })
+})
+
+Then('the payload includes checked which is set to "true"', () => {
+    cy.window().then(win => {
+        expectStubPayloadToEqual(win.onChange, 'checked', true)
+    })
+})
+
+Then('the payload includes all selected nodes', () => {
+    cy.window().then(win => {
+        expectStubPayloadToEqual(win.onChange, 'selected', ['/A0000000000'])
+    })
+})
+
+Then('the payload includes checked which is set to "false"', () => {
+    cy.window().then(win => {
+        expectStubPayloadToEqual(win.onChange, 'checked', false)
+    })
+})
+
+Then('the onExpand callback gets called', () => {
+    cy.window().then(win => {
+        expect(win.onExpand).to.be.called
+    })
+})
+
+Then('the payload includes the path of the expanded node', () => {
+    cy.window().then(win => {
+        expectStubPayloadToEqual(win.onExpand, 'path', '/A0000000000')
+    })
+})
+
+Then('the onCollapse callback gets called', () => {
+    cy.window().then(win => {
+        expect(win.onCollapse).to.be.called
+    })
+})
+
+Then('the payload includes the path of the collapsed node', () => {
+    cy.window().then(win => {
+        expectStubPayloadToEqual(win.onCollapse, 'path', '/A0000000000')
+    })
+})
+
+Then('the onChildrenLoaded callback gets called', () => {
+    cy.window().then(win => {
+        expect(win.onChildrenLoaded).to.be.called
+    })
+})
+
+Then("the payload contains the loaded children's data", () => {
+    cy.window().then(win => {
+        const calls = win.onChildrenLoaded.getCalls()
+        const { args } = calls[calls.length - 1]
+        expect(args[0].A0000000001).to.deep.eql(
+            win.dataProviderData['organisationUnits/A0000000001']
+        )
+    })
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,2 +1,3 @@
 import './screenshots'
 import './visitStory'
+import './org_unit_tree/index'

--- a/cypress/support/org_unit_tree/closeOrgUnitNode.js
+++ b/cypress/support/org_unit_tree/closeOrgUnitNode.js
@@ -1,0 +1,12 @@
+const closeOrgUnitNode = subject =>
+    cy
+        .wrap(subject, { log: false })
+        .shouldBeAnOpenNode()
+        .toggleOrgUnitNode(false)
+        .shouldBeAClosedNode()
+
+Cypress.Commands.add(
+    'closeOrgUnitNode',
+    { prevSubject: true },
+    closeOrgUnitNode
+)

--- a/cypress/support/org_unit_tree/getOrgUnitByLabel.js
+++ b/cypress/support/org_unit_tree/getOrgUnitByLabel.js
@@ -1,0 +1,13 @@
+const getOrgUnitByLabel = label => {
+    return cy
+        .get(
+            `[data-test="dhis2-uiwidgets-orgunittree-node-label"]:contains("${label}")`,
+            { log: true }
+        )
+        .parents('[data-test="dhis2-uiwidgets-orgunittree-node"]', {
+            log: false,
+        })
+        .first()
+}
+
+Cypress.Commands.add('getOrgUnitByLabel', getOrgUnitByLabel)

--- a/cypress/support/org_unit_tree/index.js
+++ b/cypress/support/org_unit_tree/index.js
@@ -1,0 +1,16 @@
+// needs to be first so other helpers have access to this one
+// Cypress tests will fail otherwise
+import './shouldBeAClosedNode'
+
+import './closeOrgUnitNode'
+import './getOrgUnitByLabel'
+import './openOrgUnitNode'
+import './shouldBeAnOpenNode'
+import './shouldBeAnOrgUnitNode'
+import './shouldHaveChildNodes'
+import './shouldNotHaveChildNodes'
+import './toggleOrgUnitNode'
+import './toggleOrgUnitNodeSelection'
+import './shouldBeASelectedOrgUnitNode'
+import './shouldNotBeASelectedOrgUnitNode'
+import './shouldBeDoneLoading'

--- a/cypress/support/org_unit_tree/openOrgUnitNode.js
+++ b/cypress/support/org_unit_tree/openOrgUnitNode.js
@@ -1,0 +1,8 @@
+const openOrgUnitNode = subject =>
+    cy
+        .wrap(subject, { log: false })
+        .shouldBeAClosedNode()
+        .toggleOrgUnitNode()
+        .shouldBeAnOpenNode()
+
+Cypress.Commands.add('openOrgUnitNode', { prevSubject: true }, openOrgUnitNode)

--- a/cypress/support/org_unit_tree/shouldBeAClosedNode.js
+++ b/cypress/support/org_unit_tree/shouldBeAClosedNode.js
@@ -1,0 +1,21 @@
+const shouldBeAClosedNode = subject => {
+    cy.wrap(subject, { log: false })
+        .shouldBeAnOrgUnitNode()
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node-leaves"]', {
+            log: false,
+        })
+        .children({ log: false })
+        .then(child => {
+            expect(
+                child.is('[data-test="dhis2-uiwidgets-orgunittree-node"]')
+            ).to.equal(false)
+        })
+
+    return cy.wrap(subject, { log: false })
+}
+
+Cypress.Commands.add(
+    'shouldBeAClosedNode',
+    { prevSubject: true },
+    shouldBeAClosedNode
+)

--- a/cypress/support/org_unit_tree/shouldBeASelectedOrgUnitNode.js
+++ b/cypress/support/org_unit_tree/shouldBeASelectedOrgUnitNode.js
@@ -1,0 +1,27 @@
+const shouldBeASelectedOrgUnitNode = (subject, singleSelection = false) => {
+    cy.wrap(subject, { log: false })
+        .shouldBeAnOrgUnitNode()
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node-label"]', {
+            log: false,
+        })
+        .first()
+        .then($label => {
+            if (singleSelection) {
+                cy.wrap($label)
+                    .find('.checked', { log: false })
+                    .should('exist')
+            } else {
+                cy.wrap($label)
+                    .find('input', { log: false })
+                    .should('have.prop', 'checked', true)
+            }
+        })
+
+    return cy.wrap(subject, { log: false })
+}
+
+Cypress.Commands.add(
+    'shouldBeASelectedOrgUnitNode',
+    { prevSubject: true },
+    shouldBeASelectedOrgUnitNode
+)

--- a/cypress/support/org_unit_tree/shouldBeAnOpenNode.js
+++ b/cypress/support/org_unit_tree/shouldBeAnOpenNode.js
@@ -1,0 +1,16 @@
+const shouldBeAnOpenNode = subject => {
+    cy.wrap(subject, { log: false })
+        .shouldBeAnOrgUnitNode()
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node-toggle"]', {
+            log: false,
+        })
+        .should('have.class', 'open')
+
+    return cy.wrap(subject, { log: false })
+}
+
+Cypress.Commands.add(
+    'shouldBeAnOpenNode',
+    { prevSubject: true },
+    shouldBeAnOpenNode
+)

--- a/cypress/support/org_unit_tree/shouldBeAnOrgUnitNode.js
+++ b/cypress/support/org_unit_tree/shouldBeAnOrgUnitNode.js
@@ -1,0 +1,11 @@
+const shouldBeAnOrgUnitNode = subject => {
+    expect(subject).to.match('[data-test="dhis2-uiwidgets-orgunittree-node"]')
+
+    return cy.wrap(subject, { log: false })
+}
+
+Cypress.Commands.add(
+    'shouldBeAnOrgUnitNode',
+    { prevSubject: true },
+    shouldBeAnOrgUnitNode
+)

--- a/cypress/support/org_unit_tree/shouldBeDoneLoading.js
+++ b/cypress/support/org_unit_tree/shouldBeDoneLoading.js
@@ -1,0 +1,13 @@
+const shouldBeDoneLoading = subject => {
+    cy.wrap(subject, { log: false }).find(
+        '> [data-test="dhis2-uiwidgets-orgunittree-node-toggle"]'
+    )
+
+    return cy.wrap(subject, { log: false })
+}
+
+Cypress.Commands.add(
+    'shouldBeDoneLoading',
+    { prevSubject: true },
+    shouldBeDoneLoading
+)

--- a/cypress/support/org_unit_tree/shouldHaveChildNodes.js
+++ b/cypress/support/org_unit_tree/shouldHaveChildNodes.js
@@ -1,0 +1,14 @@
+const shouldHaveChildNodes = subject => {
+    cy.wrap(subject, { log: false })
+        .shouldBeAnOrgUnitNode()
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node"]', { log: false })
+        .should('exist')
+
+    return cy.wrap(subject, { log: false })
+}
+
+Cypress.Commands.add(
+    'shouldHaveChildNodes',
+    { prevSubject: true },
+    shouldHaveChildNodes
+)

--- a/cypress/support/org_unit_tree/shouldNotBeASelectedOrgUnitNode.js
+++ b/cypress/support/org_unit_tree/shouldNotBeASelectedOrgUnitNode.js
@@ -1,0 +1,27 @@
+const shouldNotBeASelectedOrgUnitNode = (subject, singleSelection) => {
+    cy.wrap(subject, { log: false })
+        .shouldBeAnOrgUnitNode()
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node-label"]', {
+            log: false,
+        })
+        .first()
+        .then($label => {
+            if (singleSelection) {
+                cy.wrap($label)
+                    .find('.checked', { log: false })
+                    .should('not.exist')
+            } else {
+                cy.wrap($label)
+                    .find('input', { log: false })
+                    .should('have.prop', 'checked', false)
+            }
+        })
+
+    return cy.wrap(subject, { log: false })
+}
+
+Cypress.Commands.add(
+    'shouldNotBeASelectedOrgUnitNode',
+    { prevSubject: true },
+    shouldNotBeASelectedOrgUnitNode
+)

--- a/cypress/support/org_unit_tree/shouldNotHaveChildNodes.js
+++ b/cypress/support/org_unit_tree/shouldNotHaveChildNodes.js
@@ -1,0 +1,14 @@
+const shouldNotHaveChildNodes = subject => {
+    cy.wrap(subject, { log: false })
+        .shouldBeAnOrgUnitNode()
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node"]', { log: false })
+        .should('not.exist')
+
+    return cy.wrap(subject, { log: false })
+}
+
+Cypress.Commands.add(
+    'shouldNotHaveChildNodes',
+    { prevSubject: true },
+    shouldNotHaveChildNodes
+)

--- a/cypress/support/org_unit_tree/toggleOrgUnitNode.js
+++ b/cypress/support/org_unit_tree/toggleOrgUnitNode.js
@@ -1,0 +1,28 @@
+const toggleOrgUnitNode = (subject, toggle = true) => {
+    cy.wrap(subject, { log: false })
+        .as('toggleOrgUnitNode__node')
+        .shouldBeAnOrgUnitNode()
+
+    if (toggle) {
+        cy.get('@toggleOrgUnitNode__node', { log: false }).shouldBeAClosedNode()
+    } else {
+        cy.get('@toggleOrgUnitNode__node', { log: false }).shouldBeAnOpenNode(
+            true
+        )
+    }
+
+    cy.get('@toggleOrgUnitNode__node', { log: false })
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node-toggle"]', {
+            log: false,
+        })
+        .first()
+        .click()
+
+    return cy.wrap(subject, { log: false })
+}
+
+Cypress.Commands.add(
+    'toggleOrgUnitNode',
+    { prevSubject: true },
+    toggleOrgUnitNode
+)

--- a/cypress/support/org_unit_tree/toggleOrgUnitNodeSelection.js
+++ b/cypress/support/org_unit_tree/toggleOrgUnitNodeSelection.js
@@ -1,0 +1,34 @@
+const toggleOrgUnitNodeSelection = (
+    subject,
+    select = true,
+    singleSelection = false
+) => {
+    cy.wrap(subject, { log: false })
+        .as('toggleOrgUnitNode__node')
+        .shouldBeAnOrgUnitNode()
+
+    if (select) {
+        cy.get('@toggleOrgUnitNode__node', {
+            log: false,
+        }).shouldNotBeASelectedOrgUnitNode(singleSelection)
+    } else {
+        cy.get('@toggleOrgUnitNode__node', {
+            log: false,
+        }).shouldBeASelectedOrgUnitNode(singleSelection)
+    }
+
+    cy.get('@toggleOrgUnitNode__node', { log: false })
+        .find('[data-test="dhis2-uiwidgets-orgunittree-node-label"]', {
+            log: false,
+        })
+        .first()
+        .click()
+
+    return cy.wrap(subject, { log: false })
+}
+
+Cypress.Commands.add(
+    'toggleOrgUnitNodeSelection',
+    { prevSubject: true },
+    toggleOrgUnitNodeSelection
+)

--- a/cypress/support/visitStory.js
+++ b/cypress/support/visitStory.js
@@ -1,6 +1,12 @@
+const urlEncodeStoryBookName = name =>
+    name
+        .replace(/\(|\)/g, '')
+        .replace(/[^a-zA-Z0-9]+/g, '-')
+        .toLowerCase()
+
 Cypress.Commands.add('visitStory', (namespace, storyName, options = {}) => {
-    const formattedNamespace = namespace.toLowerCase()
-    const formattedStoryName = storyName.replace(/ /g, '-').toLowerCase()
+    const formattedNamespace = urlEncodeStoryBookName(namespace)
+    const formattedStoryName = urlEncodeStoryBookName(storyName)
     const id = `${formattedNamespace}--${formattedStoryName}`
 
     /**

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-05-06T10:04:38.118Z\n"
-"PO-Revision-Date: 2019-05-06T10:04:38.118Z\n"
+"POT-Creation-Date: 2020-02-18T13:19:29.126Z\n"
+"PO-Revision-Date: 2020-02-18T13:19:29.126Z\n"
 
 msgid "Search apps"
 msgstr ""
@@ -27,4 +27,7 @@ msgid "About DHIS2"
 msgstr ""
 
 msgid "Logout"
+msgstr ""
+
+msgid "Something went wrong with loading the children."
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
         "format": "yarn format:js && yarn format:text",
         "format:js": "d2-style js apply",
         "format:text": "d2-style text apply",
-        "format:staged": "yarn format:js --staged && yarn format:text --staged"
+        "format:staged": "yarn format:js --staged && yarn format:text --staged",
+        "test": "d2-app-scripts test"
     },
     "devDependencies": {
-        "@dhis2/app-runtime": "^2",
+        "@dhis2/app-runtime": "^2.1",
         "@dhis2/cli-app-scripts": "^3.2.5",
         "@dhis2/cli-style": "^6.0.0",
         "@dhis2/d2-i18n": "^1.0.6",
@@ -51,10 +52,10 @@
         "storybook-addon-react-docgen": "^1.2.2",
         "styled-jsx": "^3.2.4",
         "typeface-roboto": "^0.0.75",
-        "wait-on": "^4.0.1"
+        "wait-on": "^4.0.0"
     },
     "peerDependencies": {
-        "@dhis2/app-runtime": "^2",
+        "@dhis2/app-runtime": "^2.1",
         "@dhis2/d2-i18n": "^1",
         "@dhis2/ui-core": "^4",
         "react": "^16.8",

--- a/src/OrganisationUnitTree.js
+++ b/src/OrganisationUnitTree.js
@@ -1,0 +1,219 @@
+import React, { useEffect } from 'react'
+import propTypes from 'prop-types'
+
+import { OrganisationUnitNode } from './OrganisationUnitTree/OrganisationUnitNode'
+import { RootError } from './OrganisationUnitTree/RootError'
+import { RootLoading } from './OrganisationUnitTree/RootLoading'
+import { orgUnitPathPropType } from './OrganisationUnitTree/propTypes'
+import { useExpanded } from './OrganisationUnitTree/useExpanded'
+import { useForceReload } from './OrganisationUnitTree/useForceReload'
+import { useOrgData } from './OrganisationUnitTree/useOrgData'
+
+/**
+ * @module
+ * @param {OrganisationUnitTree.PropTypes} props
+ * @returns {React.Component}
+ *
+ * @example
+ * import { OrganisationUnitTree } from '@dhis2/ui-widgets'
+ *
+ * @example
+ * <OrganisationUnitTree
+ *     name="Root org unit"
+ *     roots="A0000000000"
+ *     onChange={onChange}
+ *     onExpand={onExpand}
+ *     onCollapse={onCollapse}
+ *     onChildrenLoaded={onChildrenLoaded}
+ *     initiallyExpanded={['/A0000000000/A0000000001']}
+ *     filter={['/A0000000000/A0000000001/A0000000003']}
+ * />
+ *
+ * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/organisms/organisation-unit-tree/org-unit-tree.md|Design system}
+ * @see Live demo: {@link /demo/?path=/story/organisationunittree--collapsed|Storybook}
+ */
+const OrganisationUnitTree = ({
+    onChange,
+    roots,
+
+    autoExpandLoadingError,
+    dataTest,
+    disableSelection,
+    forceReload,
+    highlighted,
+    isUserDataViewFallback,
+    initiallyExpanded,
+    filter,
+    selected,
+    singleSelection,
+
+    onExpand,
+    onCollapse,
+    onChildrenLoaded,
+}) => {
+    const rootIds = Array.isArray(roots) ? roots : [roots]
+    const reloadId = useForceReload(forceReload)
+    const { loading, error, data, refetch } = useOrgData(rootIds, {
+        withChildren: false,
+        isUserDataViewFallback,
+    })
+    const { expanded, handleExpand, handleCollapse } = useExpanded(
+        initiallyExpanded,
+        onExpand,
+        onCollapse
+    )
+
+    useEffect(() => {
+        // do not refetch on initial render
+        if (refetch && reloadId > 0) {
+            refetch()
+        }
+    }, [reloadId, refetch])
+
+    return (
+        <div data-test={dataTest}>
+            {error && <RootError error={error} dataTest={dataTest} />}
+            {loading && <RootLoading dataTest={dataTest} />}
+            {!error &&
+                !loading &&
+                rootIds.map(rootId => {
+                    const rootNode = data[rootId]
+                    const rootPath = `/${rootId}`
+
+                    return (
+                        <OrganisationUnitNode
+                            key={rootPath}
+                            autoExpandLoadingError={autoExpandLoadingError}
+                            dataTest={dataTest}
+                            disableSelection={disableSelection}
+                            displayName={rootNode.displayName}
+                            expanded={expanded}
+                            highlighted={highlighted}
+                            id={rootId}
+                            isUserDataViewFallback={isUserDataViewFallback}
+                            filter={filter}
+                            path={rootPath}
+                            selected={selected}
+                            singleSelection={singleSelection}
+                            onChange={onChange}
+                            onChildrenLoaded={onChildrenLoaded}
+                            onCollapse={handleCollapse}
+                            onExpand={handleExpand}
+                        />
+                    )
+                })}
+        </div>
+    )
+}
+
+/**
+ * @typedef {Object} PropTypes
+ * @static
+ *
+ * @prop {string|string[]} roots
+ * Root org unit id(s)
+ *
+ * @prop {Function} onChange
+ * Will be called with the following object
+ * { id: string; path: string; checked: boolean; }
+ *
+ * @prop {bool} [autoExpandLoadingError]
+ * When set, the error when loading children
+ * fails will be shown automaticlly
+ *
+ * @prop {bool} [singleSelection]
+ * When set, no checkboxes will be displayed and only the first selected path
+ * in `selected` will be highlighted
+ *
+ * @prop {bool} [disableSelection]
+ * When set to true, no unit can be selected
+ *
+ * @prop {string[]} [filter]
+ * All organisation units with a path that inclused the provided
+ * paths will be shown. All others will not be rendered.
+ * When not provided, all org units will be shown.
+ *
+ * @prop {bool} [forceReload]
+ * When set to "true", everything will be reloaded.
+ * In order to load it again after reloading,
+ * "forceReload" has to be set to false and then to true again
+ *
+ * @prop {string[]} [selected]
+ * An array of paths of selected OUs.
+ * The path of an OU is the UIDs of the OU and all its parent OUs separated
+ * by slashes (/)
+ *
+ * @prop {string[]} [initiallyExpanded]
+ * An array of OU paths that will be expanded automatically
+ * as soon as they are encountered.
+ * The path of an OU is the UIDs of the OU
+ * and all its parent OUs separated by slashes (/)
+ * Note: This replaces "openFirstLevel" as that's redundant
+ *
+ * @prop {bool} [isUserDataViewFallback]
+ * When provided, the "isUserDataViewFallback" option will be send when
+ * requesting the org units
+ *
+ * @prop {string[]} [highlighted]
+ * All units provided to "highlighted" as path will be visually
+ * highlighted.
+ * Note:
+ * The d2-ui component used two props for this:
+ * * searchResults
+ * * highlightSearchResults
+ *
+ * @prop {Function} [onExpand]
+ * Called with { path: string }
+ * with the path of the parent of the level opened
+ *
+ * @prop {Function} [onCollapse]
+ * Called with { path: string }
+ * with the path of the parent of the level closed
+ *
+ * @prop {Function} [onChildrenLoaded]
+ * Called with the children's data that was loaded
+ */
+OrganisationUnitTree.propTypes = {
+    roots: propTypes.oneOfType([
+        propTypes.string,
+        propTypes.arrayOf(propTypes.string),
+    ]).isRequired,
+    onChange: propTypes.func.isRequired,
+
+    autoExpandLoadingError: propTypes.bool,
+    dataTest: propTypes.string,
+    disableSelection: propTypes.bool,
+    filter: propTypes.arrayOf(orgUnitPathPropType),
+    forceReload: propTypes.bool,
+    highlighted: propTypes.arrayOf(orgUnitPathPropType),
+    initiallyExpanded: propTypes.arrayOf(orgUnitPathPropType),
+    isUserDataViewFallback: propTypes.bool,
+    selected: propTypes.arrayOf(orgUnitPathPropType),
+    singleSelection: propTypes.bool,
+    onChildrenLoaded: propTypes.func,
+    onCollapse: propTypes.func,
+    onExpand: propTypes.func,
+
+    /**
+     * @prop {string[]} [idsThatShouldBeReloaded]
+     * All units with ids (not paths!) provided
+     * to "idsThatShouldBeReloaded" will be reloaded
+     * In order to reload an id twice, the array must be changed
+     * while keeping the id to reload in the array
+     *
+     * NOTE: This is currently not working due to a limitation
+     * of the data engine (we can't force specific resource to reload,
+     * we'd have to reload the sibling nodes currently as well)
+     */
+    //idsThatShouldBeReloaded: propTypes.arrayOf(orgUnitIdPropType),
+}
+
+OrganisationUnitTree.defaultProps = {
+    dataTest: 'dhis2-uiwidgets-orgunittree',
+    filter: [],
+    highlighted: [],
+    initiallyExpanded: [],
+    selected: [],
+}
+
+export { OrganisationUnitTree }

--- a/src/OrganisationUnitTree/ErrorMessage.js
+++ b/src/OrganisationUnitTree/ErrorMessage.js
@@ -1,0 +1,23 @@
+import { colors, spacers, theme } from '@dhis2/ui-core'
+import React from 'react'
+import propTypes from 'prop-types'
+
+export const ErrorMessage = ({ children, dataTest }) => (
+    <span data-test={`${dataTest}-error`}>
+        {children}
+
+        <style jsx>{`
+            span {
+                font-size: 14px;
+                color: ${colors.grey800};
+                margin: ${spacers.dp4};
+                color: ${theme.error};
+            }
+        `}</style>
+    </span>
+)
+
+ErrorMessage.propTypes = {
+    children: propTypes.any.isRequired,
+    dataTest: propTypes.string.isRequired,
+}

--- a/src/OrganisationUnitTree/Label.js
+++ b/src/OrganisationUnitTree/Label.js
@@ -1,0 +1,338 @@
+import { Checkbox, colors } from '@dhis2/ui-core'
+import React from 'react'
+import propTypes from 'prop-types'
+import cx from 'classnames'
+
+import { FolderOpen } from './icons/FolderOpen'
+import { FolderClosed } from './icons/FolderClosed'
+import { Single } from './icons/Single'
+import { Empty } from './icons/Empty'
+import { orgUnitPathPropType } from './propTypes'
+
+/**
+ * @param {Object} props
+ * @param {string} props.label
+ * @param {Function} props.onToggleOpen
+ * @param {bool} [props.loading]
+ * @returns {React.Component}
+ */
+const DisabledSelectionLabel = ({ label, loading, onToggleOpen }) => (
+    <SingleSelectionLabel
+        checked={false}
+        loading={loading}
+        label={label}
+        onChange={onToggleOpen}
+    />
+)
+
+DisabledSelectionLabel.propTypes = {
+    label: propTypes.string.isRequired,
+    onToggleOpen: propTypes.func.isRequired,
+    loading: propTypes.bool,
+}
+
+/**
+ * @param {Object} props
+ * @param {string} props.label
+ * @param {bool} [props.checked]
+ * @param {bool} [props.loading]
+ * @param {Function} [props.onChange]
+ * @returns {React.Component}
+ */
+const SingleSelectionLabel = ({ checked, label, onChange, loading }) => (
+    <span
+        onClick={event => {
+            const payload = { checked: !checked }
+            onChange(payload, event)
+        }}
+        className={cx({ checked, loading })}
+    >
+        {label}
+
+        <style jsx>{`
+            span {
+                background: transparent;
+                border-radius: 3px;
+                color: ${colors.grey900};
+                cursor: pointer;
+                display: inline-block;
+                font-size: 14px;
+                line-height: 24px;
+                padding: 0 5px;
+                user-select: none;
+                white-space: nowrap;
+            }
+
+            .checked {
+                background: ${colors.teal700};
+                color: white;
+            }
+
+            .loading {
+                cursor: auto;
+            }
+        `}</style>
+    </span>
+)
+
+SingleSelectionLabel.propTypes = {
+    label: propTypes.string.isRequired,
+    checked: propTypes.bool,
+    loading: propTypes.bool,
+    onChange: propTypes.func,
+}
+
+/**
+ * @param {Object} props
+ * @param {bool} props.highlighted
+ * @param {React.Component|React.Component[]} props.children
+ * @returns {React.Component}
+ */
+const LabelContainer = ({ highlighted, children }) => (
+    <div className={cx({ highlighted })}>
+        <span>{children}</span>
+
+        <style jsx>{`
+            div {
+                display: flex;
+            }
+
+            span {
+                display: block;
+            }
+
+            .highlighted {
+                background: ${colors.teal200};
+                padding-right: 4px;
+            }
+        `}</style>
+    </div>
+)
+
+LabelContainer.propTypes = {
+    children: propTypes.node,
+    highlighted: propTypes.bool,
+}
+
+/**
+ * @param {Object} props
+ * @param {bool} props.hasChildren
+ * @param {bool} props.open
+ * @returns {React.Component}
+ */
+const Icon = ({ loading, hasChildren, open, dataTest }) => {
+    if (loading) {
+        return <Empty dataTest={dataTest} />
+    }
+
+    if (!hasChildren) {
+        return <Single dataTest={dataTest} />
+    }
+
+    if (open) {
+        return <FolderOpen dataTest={dataTest} />
+    }
+
+    return <FolderClosed dataTest={dataTest} />
+}
+
+Icon.propTypes = {
+    dataTest: propTypes.string.isRequired,
+    hasChildren: propTypes.bool,
+    loading: propTypes.bool,
+    open: propTypes.bool,
+}
+
+const IconizedCheckbox = ({
+    checked,
+    dataTest,
+    hasChildren,
+    indeterminate,
+    label,
+    loading,
+    name,
+    open,
+    value,
+    onChange,
+}) => {
+    const icon = (
+        <Icon
+            loading={loading}
+            open={open}
+            hasChildren={hasChildren}
+            dataTest={dataTest}
+        />
+    )
+
+    const checkboxLabel = (
+        <>
+            <span>{icon}</span>
+            {label}
+
+            <style jsx>{`
+                span {
+                    display: inline-block;
+                    margin-right: 4px;
+                }
+            `}</style>
+        </>
+    )
+
+    return (
+        <>
+            <Checkbox
+                dense
+                checked={checked}
+                name={name}
+                value={value}
+                label={checkboxLabel}
+                indeterminate={indeterminate}
+                onChange={onChange}
+            />
+        </>
+    )
+}
+
+IconizedCheckbox.propTypes = {
+    checked: propTypes.bool.isRequired,
+    dataTest: propTypes.string.isRequired,
+    hasChildren: propTypes.bool.isRequired,
+    indeterminate: propTypes.bool.isRequired,
+    label: propTypes.string.isRequired,
+    loading: propTypes.bool.isRequired,
+    name: propTypes.string.isRequired,
+    open: propTypes.bool.isRequired,
+    value: propTypes.string.isRequired,
+    onChange: propTypes.func.isRequired,
+}
+
+const createNewSelected = ({ selected, path, checked, singleSelection }) => {
+    const pathIndex = selected.indexOf(path)
+
+    if (checked && pathIndex !== -1) return selected
+    if (singleSelection && checked) return [path]
+    if (checked) return [...selected, path]
+    if (pathIndex === -1) return selected
+    if (singleSelection) return []
+    if (selected.indexOf(path) === 0) return selected.slice(1)
+
+    const prevSlice = selected.slice(0, pathIndex)
+    const nextSlice = selected.slice(pathIndex + 1)
+    return [...prevSlice, ...nextSlice]
+}
+
+/**
+ * @module
+ * @param {Label.PropTypes} props
+ * @returns {React.Component}
+ */
+const Label = ({
+    id,
+    path,
+    open,
+    loading,
+    checked,
+    onChange,
+    dataTest,
+    selected,
+    hasChildren,
+    highlighted,
+    displayName,
+    onToggleOpen,
+    disableSelection,
+    singleSelection,
+    hasSelectedDescendants,
+}) => {
+    const onClick = ({ checked }, event) => {
+        const newSelected = createNewSelected({
+            selected,
+            path,
+            checked,
+            singleSelection,
+        })
+
+        onChange({ id, path, checked, selected: newSelected }, event)
+    }
+
+    if (disableSelection) {
+        return (
+            <LabelContainer highlighted={highlighted}>
+                <DisabledSelectionLabel
+                    label={displayName}
+                    loading={loading}
+                    onToggleOpen={onToggleOpen}
+                />
+            </LabelContainer>
+        )
+    }
+
+    if (singleSelection) {
+        return (
+            <LabelContainer highlighted={highlighted}>
+                <SingleSelectionLabel
+                    checked={checked}
+                    label={displayName}
+                    onChange={onClick}
+                    loading={loading}
+                >
+                    {displayName}
+                </SingleSelectionLabel>
+            </LabelContainer>
+        )
+    }
+
+    return (
+        <LabelContainer highlighted={highlighted}>
+            <IconizedCheckbox
+                dataTest={dataTest}
+                checked={checked}
+                name="org-unit"
+                value={id}
+                label={displayName}
+                loading={loading}
+                indeterminate={!checked && hasSelectedDescendants}
+                onChange={onClick}
+                open={open}
+                hasChildren={hasChildren}
+            />
+        </LabelContainer>
+    )
+}
+
+/**
+ * @typedef {Object} PropTypes
+ * @static
+ *
+ * @prop {string} id
+ * @prop {string} path
+ * @prop {string} displayName
+ * @prop {bool} open
+ * @prop {bool} loading
+ * @prop {bool} hasChildren
+ * @prop {Function} [onChange]
+ * @prop {Function} [onToggleOpen]
+ * @prop {bool} [checked]
+ * @prop {bool} [highlighted]
+ * @prop {bool} [disableSelection]
+ * @prop {bool} [singleSelection]
+ * @prop {bool} [hasSelectedDescendants]
+ */
+Label.propTypes = {
+    dataTest: propTypes.string.isRequired,
+    displayName: propTypes.string.isRequired,
+    hasChildren: propTypes.bool.isRequired,
+    id: propTypes.string.isRequired,
+    loading: propTypes.bool.isRequired,
+    open: propTypes.bool.isRequired,
+    path: propTypes.string.isRequired,
+    onChange: propTypes.func.isRequired,
+    onToggleOpen: propTypes.func.isRequired,
+    checked: propTypes.bool,
+    disableSelection: propTypes.bool,
+    hasSelectedDescendants: propTypes.bool,
+    highlighted: propTypes.bool,
+    selected: propTypes.arrayOf(orgUnitPathPropType),
+    singleSelection: propTypes.bool,
+}
+
+export { Label }

--- a/src/OrganisationUnitTree/OrganisationUnitNode.js
+++ b/src/OrganisationUnitTree/OrganisationUnitNode.js
@@ -1,0 +1,193 @@
+/* eslint-disable */
+/**
+ * REMOVE THE ESLINT-DISABLE
+ * !!!!!!!!!!!!!!!!!!!!!!!!!
+ * !!!!!!!!! BEFORE !!!!!!!!
+ * !!!!!!!!!!!!!!!!!!!!!!!!!
+ * APPROVING THE PR
+ */
+import { CircularLoader, Node } from '@dhis2/ui-core';
+import { resolve } from 'styled-jsx/css'
+import React, { useEffect } from 'react'
+import i18n from '@dhis2/d2-i18n'
+import propTypes from '@dhis2/prop-types'
+
+import { ErrorMessage } from './ErrorMessage';
+import { Label } from './Label';
+import { computeChildNodes } from './computeChildNodes';
+import { hasDescendantSelectedPaths } from './hasDescendantSelectedPaths';
+import { orgUnitIdPropType, orgUnitPathPropType } from './propTypes';
+import { useOpenState } from './useOpenState';
+import { useOrgData } from './useOrgData';
+
+const loadingSpinnerStyles = resolve`
+    .small {
+        display: block;
+        margin: 3px 0;
+        width: 18px;
+        height: 18px;
+    }
+`
+
+const LoadingSpinner = () => (
+    <div>
+        <CircularLoader small className={loadingSpinnerStyles.className} />
+        <style>{loadingSpinnerStyles.styles}</style>
+        <style jsx>{`
+            div {
+                width: 24px;
+            }
+        `}</style>
+    </div>
+)
+
+export const OrganisationUnitNode = ({
+    autoExpandLoadingError,
+    dataTest,
+    disableSelection,
+    displayName,
+    expanded,
+    highlighted,
+    id,
+    isUserDataViewFallback,
+    path,
+    selected,
+    singleSelection,
+    filter,
+    onChange,
+    onChildrenLoaded,
+    onCollapse,
+    onExpand,
+}) => {
+    const { loading, error, data } = useOrgData([id], { isUserDataViewFallback })
+    const childNodes = !loading && !error
+        ? computeChildNodes(data[id], filter)
+        : []
+    const hasChildren = !!childNodes.length
+    const hasSelectedDescendants = hasDescendantSelectedPaths(path, selected)
+    const isHighlighted = highlighted.includes(path)
+    const { open, onToggleOpen } = useOpenState({
+        autoExpandLoadingError,
+        errorMessage: error && error.toString(),
+        path,
+        expanded,
+        onExpand,
+        onCollapse,
+    })
+
+    const isSelected = selected.includes(path)
+
+    useEffect(
+        () => {
+            if (!loading && !error && onChildrenLoaded) {
+                onChildrenLoaded(data)
+            }
+        },
+        [ loading, error, onChildrenLoaded ]
+    )
+
+    const label = (
+        <Label
+            checked={isSelected}
+            dataTest={`${dataTest}-label`}
+            disableSelection={disableSelection}
+            displayName={displayName}
+            hasChildren={hasChildren}
+            hasSelectedDescendants={hasSelectedDescendants}
+            highlighted={isHighlighted}
+            id={id}
+            loading={loading}
+            onChange={onChange}
+            selected={selected}
+            onToggleOpen={onToggleOpen}
+            open={open}
+            path={path}
+            singleSelection={singleSelection}
+        />
+    )
+
+    /**
+     * No children means no arrow, therefore we have to provide something.
+     * While "loading" is true, "hasChildren" is false
+     * There are some possible children variants as content of this node:
+     *
+     * 1. Nothing; There are no children
+     * 2. Placeholder: There are children, but the Node is closed (show arrow)
+     * 3. Error: There are children and loading information somehow failed
+     * 4. Child nodes: There are children and the node is open
+     */
+    const showPlaceholder = hasChildren && !open && !error
+    const showChildNodes = hasChildren && open && !error
+
+    return (
+        <Node
+            dataTest={`${dataTest}-node`}
+            open={open}
+            onOpen={onToggleOpen}
+            onClose={onToggleOpen}
+            component={label}
+            icon={loading && <LoadingSpinner />}
+        >
+            {error && (
+                <ErrorMessage dataTest={dataTest}>
+                    {i18n.t('Could not load children')}
+                </ErrorMessage>
+            )}
+            {showPlaceholder && <span data-test={`${dataTest}-placeholder`} />}
+            {showChildNodes && childNodes.map(child => {
+                const childPath = `${path}/${child.id}`
+                const grandChildNodes = computeChildNodes(child, filter)
+
+                return (
+                    <OrganisationUnitNode
+                        key={childPath}
+                        autoExpandLoadingError={autoExpandLoadingError}
+                        childNodes={grandChildNodes}
+                        dataTest={dataTest}
+                        disableSelection={disableSelection}
+                        displayName={child.displayName}
+                        expanded={expanded}
+                        filter={filter}
+                        highlighted={highlighted}
+                        id={child.id}
+                        isUserDataViewFallback={isUserDataViewFallback}
+                        path={childPath}
+                        selected={selected}
+                        singleSelection={singleSelection}
+                        onChange={onChange}
+                        onChildrenLoaded={onChildrenLoaded}
+                        onCollapse={onCollapse}
+                        onExpand={onExpand}
+                    />
+                )
+            })}
+        </Node>
+    )
+}
+
+OrganisationUnitNode.propTypes = {
+    dataTest: propTypes.string.isRequired,
+    id: propTypes.string.isRequired,
+    onChange: propTypes.func.isRequired,
+
+    autoExpandLoadingError: propTypes.bool,
+    disableSelection: propTypes.bool,
+    displayName: propTypes.string,
+    expanded: propTypes.arrayOf(orgUnitPathPropType),
+    filter: propTypes.arrayOf(orgUnitPathPropType),
+    /**
+     * The parent already knows whether this node has children or not
+     * before we load the children's details, so we can use this information
+     * even during the loading phase
+     */
+    hasChildren: propTypes.bool,
+    highlighted: propTypes.arrayOf(orgUnitPathPropType),
+    isUserDataViewFallback: propTypes.bool,
+    path: orgUnitPathPropType,
+    selected: propTypes.arrayOf(orgUnitPathPropType),
+    singleSelection: propTypes.bool,
+
+    onCollapse: propTypes.func,
+    onExpand: propTypes.func,
+    onChildrenLoaded: propTypes.func,
+}

--- a/src/OrganisationUnitTree/RootError.js
+++ b/src/OrganisationUnitTree/RootError.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+import propTypes from 'prop-types'
+
+export const RootError = ({ dataTest, error }) => (
+    <div data-test={`${dataTest}-loading`}>
+        {i18n.t('Error: ')}
+        {error}
+    </div>
+)
+
+RootError.propTypes = {
+    dataTest: propTypes.string.isRequired,
+    error: propTypes.string.isRequired,
+}

--- a/src/OrganisationUnitTree/RootLoading.js
+++ b/src/OrganisationUnitTree/RootLoading.js
@@ -1,0 +1,20 @@
+import { CircularLoader } from '@dhis2/ui-core'
+import React from 'react'
+import propTypes from 'prop-types'
+
+export const RootLoading = ({ dataTest }) => (
+    <div data-test={`${dataTest}-loading`}>
+        <CircularLoader small />
+
+        <style jsx>{`
+            div {
+                display: flex;
+                justify-content: center;
+            }
+        `}</style>
+    </div>
+)
+
+RootLoading.propTypes = {
+    dataTest: propTypes.string.isRequired,
+}

--- a/src/OrganisationUnitTree/__tests__/computeChildNodes.test.js
+++ b/src/OrganisationUnitTree/__tests__/computeChildNodes.test.js
@@ -1,0 +1,85 @@
+import { computeChildNodes } from '../computeChildNodes'
+
+describe('computeChildNodes', () => {
+    let node = { path: 'foo/bar' }
+    const defaultChildren = [
+        { id: 'foobar' },
+        { id: 'barbaz' },
+        { id: 'foobarbaz' },
+    ]
+    const defaultChildrenIds = defaultChildren
+    const irrelevantPaths = ['irrelevant/path']
+    const pathsToIncludeWithMatchingAncestors = [
+        'foo/bar/foobar/barbaz',
+        'foo/bar/barbaz/bazbazfoo',
+    ]
+    const pathsToIncludeWithMatchingChildren = ['foo/bar/foobar']
+    const pathsToIncludeWithMatchingParents = ['foo/bar']
+
+    beforeEach(() => {
+        node = { path: 'foo/bar' }
+    })
+
+    it('should return all children when filter is empty', () => {
+        node.children = defaultChildren
+        const filter = []
+        const actual = computeChildNodes(node, filter)
+        const expected = defaultChildrenIds
+
+        expect(actual).toEqual(expected)
+    })
+
+    it("should return an empty array when the node has children but neither the children's or the parent path are in filter", () => {
+        node.children = defaultChildren
+        const filter = irrelevantPaths
+        const actual = computeChildNodes(node, filter)
+        const expected = []
+
+        expect(actual).toEqual(expected)
+    })
+
+    it('should return an empty array when filter contains none of the child paths but a parent path', () => {
+        node.children = defaultChildren
+        const filter = pathsToIncludeWithMatchingParents
+        const actual = computeChildNodes(node, filter)
+        const expected = []
+
+        expect(actual).toEqual(expected)
+    })
+
+    it('should return some the children ids when filter contains none of the child paths but some ancestor paths', () => {
+        node.children = defaultChildren
+        const filter = pathsToIncludeWithMatchingAncestors
+        const actual = computeChildNodes(node, filter)
+        const expected = [{ id: 'foobar' }, { id: 'barbaz' }]
+
+        expect(actual).toEqual(expected)
+    })
+
+    it('should return one of the children ids when filter contains one of the child paths but no parent path', () => {
+        node.children = defaultChildren
+        const filter = pathsToIncludeWithMatchingChildren
+        const actual = computeChildNodes(node, filter)
+        const expected = [{ id: 'foobar' }]
+
+        expect(actual).toEqual(expected)
+    })
+
+    it('should return an empty array when the node has no children but filter is not empty', () => {
+        node.children = []
+        const filter = pathsToIncludeWithMatchingParents
+        const actual = computeChildNodes(node, filter)
+        const expected = []
+
+        expect(actual).toEqual(expected)
+    })
+
+    it('should return an empty array when the node has no children and filter is empty', () => {
+        node.children = []
+        const filter = []
+        const actual = computeChildNodes(node, filter)
+        const expected = []
+
+        expect(actual).toEqual(expected)
+    })
+})

--- a/src/OrganisationUnitTree/__tests__/fromEntries.test.js
+++ b/src/OrganisationUnitTree/__tests__/fromEntries.test.js
@@ -1,0 +1,14 @@
+import { fromEntries } from '../fromEntries'
+
+describe('fromEntries', () => {
+    it('should transform an array of entries to an object', () => {
+        const expected = { key1: 'value1', key2: 'value2', key3: 'value3' }
+        const actual = fromEntries([
+            ['key1', 'value1'],
+            ['key2', 'value2'],
+            ['key3', 'value3'],
+        ])
+
+        expect(actual).toEqual(expected)
+    })
+})

--- a/src/OrganisationUnitTree/__tests__/hasDescendantSelectedPaths.test.js
+++ b/src/OrganisationUnitTree/__tests__/hasDescendantSelectedPaths.test.js
@@ -1,0 +1,30 @@
+import { hasDescendantSelectedPaths } from '../hasDescendantSelectedPaths'
+
+describe('hasDescendantSelectedPaths', () => {
+    it('should return true when the path is a parent path of one of the selected paths', () => {
+        const path = '/foo/bar'
+        const selected = ['/foo/bar/baz', '/foobar/barbaz/']
+        const expected = true
+        const actual = hasDescendantSelectedPaths(path, selected)
+
+        expect(actual).toBe(expected)
+    })
+
+    it('should return false when the paths is not a parent path but an exact match with one of the selected paths', () => {
+        const path = '/foo/bar/baz'
+        const selected = ['/foo/bar/baz', '/foobar/barbaz/']
+        const expected = false
+        const actual = hasDescendantSelectedPaths(path, selected)
+
+        expect(actual).toBe(expected)
+    })
+
+    it('should return false when the paths is neither a parent path nor an exact match with one of the selected paths', () => {
+        const path = '/foobarbaz/boofarzab'
+        const selected = ['/foo/bar/baz', '/foobar/barbaz/']
+        const expected = false
+        const actual = hasDescendantSelectedPaths(path, selected)
+
+        expect(actual).toBe(expected)
+    })
+})

--- a/src/OrganisationUnitTree/__tests__/useExpanded.test.js
+++ b/src/OrganisationUnitTree/__tests__/useExpanded.test.js
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+
+import {
+    createExpandHandlers,
+    getInitiallyExpandedPaths,
+} from '../useExpanded/helpers'
+import { useExpanded } from '../useExpanded'
+
+jest.mock('react', () => ({
+    useState: jest.fn(initialValue => [initialValue, () => null]),
+}))
+
+jest.mock('../useExpanded/helpers', () => ({
+    getInitiallyExpandedPaths: jest.fn(input => input),
+    createExpandHandlers: jest.fn(() => ({
+        handleCollapse: () => null,
+        handleExpand: () => null,
+    })),
+}))
+
+describe('OrganisationUnitTree - useExpanded hook', () => {
+    it('should use the getInitiallyExpandedPaths helper to determine the initial state', () => {
+        getInitiallyExpandedPaths.mockImplementationOnce(input => [
+            ...input,
+            '/foo/bar/baz',
+        ])
+        const expected = ['/foo', '/foo/bar', '/foo/bar/baz']
+        const { expanded: actual } = useExpanded(['/foo', '/foo/bar'])
+
+        expect(actual).toEqual(expected)
+    })
+
+    it('should pass the setExpanded function from seState to createExpandHandlers', () => {
+        const setExpanded = jest.fn()
+        useState.mockImplementationOnce(() => [[], setExpanded])
+
+        useExpanded([])
+        expect(createExpandHandlers).toHaveBeenCalledWith(
+            expect.objectContaining({ setExpanded })
+        )
+    })
+})

--- a/src/OrganisationUnitTree/__tests__/useForceReload.test.js
+++ b/src/OrganisationUnitTree/__tests__/useForceReload.test.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { useForceReload } from '../useForceReload'
+
+jest.mock('react', () => ({
+    useEffect: jest.fn(callback => callback()),
+    useState: jest.fn(iV => [iV, () => null]),
+}))
+
+describe('OrganisationUnitTree - useForceReload', () => {
+    afterEach(() => {
+        useEffect.mockClear()
+    })
+
+    it('should return an reloadIf of 0 when forceReload is false', () => {
+        const expected = 0
+        const actual = useForceReload(false)
+
+        expect(actual).toBe(expected)
+    })
+
+    it('should increase the default reloadId when forceReload is true', () => {
+        useState.mockImplementationOnce(initialValue => [
+            initialValue,
+            setReloadId,
+        ])
+
+        const setReloadId = jest.fn()
+        const expected = 1
+
+        useForceReload(true)
+
+        expect(setReloadId).toHaveBeenCalledWith(expected)
+    })
+
+    it('should pass forceReload as only item as the second argument to useEffect', () => {
+        const forceReload = true
+        useForceReload(forceReload)
+
+        const useEffectDependencies = useEffect.mock.calls[0][1]
+
+        expect(useEffectDependencies).toEqual([forceReload])
+    })
+})

--- a/src/OrganisationUnitTree/__tests__/useOpenState.test.js
+++ b/src/OrganisationUnitTree/__tests__/useOpenState.test.js
@@ -1,0 +1,161 @@
+import { useEffect, useState } from 'react'
+import { useOpenState } from '../useOpenState'
+
+jest.mock('react', () => ({
+    useState: jest.fn(),
+    useEffect: jest.fn(),
+}))
+
+describe('OrganisationUnitTree - useOpenState', () => {
+    const onExpand = jest.fn()
+    const onCollapse = jest.fn()
+
+    beforeEach(() => {
+        useState.mockImplementation(initialValue => [initialValue, () => null])
+        useEffect.mockImplementation(callback => callback())
+    })
+
+    afterEach(() => {
+        onExpand.mockClear()
+        onCollapse.mockClear()
+    })
+
+    it('should not have an initial open state if the path is not in the expanded array', () => {
+        const path = '/foo'
+        const expanded = ['/bar']
+        const expected = false
+        const { open: actual } = useOpenState({ path, expanded })
+
+        expect(actual).toBe(expected)
+    })
+
+    it('should have an initial open state if the path is in the expanded array', () => {
+        const path = '/foo'
+        const expanded = ['/foo']
+        const expected = true
+        const { open: actual } = useOpenState({ path, expanded })
+
+        expect(actual).toBe(expected)
+    })
+
+    it('should call setOpen with false when calling onToggleOpen if open is true', () => {
+        let useStateCall = 0
+        const open = true
+        const setOpen = jest.fn()
+
+        useState.mockImplementation(initialValue => {
+            useStateCall++
+
+            if (useStateCall === 1) {
+                return [initialValue, jest.fn()]
+            }
+
+            return [open, setOpen]
+        })
+
+        const path = '/foo'
+        const expanded = ['/foo']
+
+        const { onToggleOpen } = useOpenState({ path, expanded })
+        onToggleOpen()
+
+        expect(setOpen).toHaveBeenCalledWith(!open)
+    })
+
+    it('should call setOpen with true when calling onToggleOpen if open is false', () => {
+        let useStateCall = 0
+        const open = true
+        const setOpen = jest.fn()
+
+        useState.mockImplementation(initialValue => {
+            useStateCall++
+
+            if (useStateCall === 1) {
+                return [initialValue, jest.fn()]
+            }
+
+            return [open, setOpen]
+        })
+
+        const { onToggleOpen } = useOpenState({ path: '/foo', expanded: [] })
+        onToggleOpen()
+
+        expect(setOpen).toHaveBeenCalledWith(!open)
+    })
+
+    it('should call the onExpand callback with the path when calling onToggleOpen and open was false', () => {
+        useState.mockImplementation(() => [false, jest.fn()])
+
+        const path = '/foo'
+        const { onToggleOpen } = useOpenState({
+            path,
+            expanded: [],
+            onExpand,
+            onCollapse,
+        })
+
+        onToggleOpen()
+
+        expect(onExpand).toHaveBeenCalledWith({ path })
+        expect(onCollapse).toHaveBeenCalledTimes(0)
+    })
+
+    it('should call the onCollapse callback with the path when calling onToggleOpen and open was true', () => {
+        useState.mockImplementation(() => [true, jest.fn()])
+
+        const path = '/foo'
+        const { onToggleOpen } = useOpenState({
+            path,
+            expanded: [],
+            onExpand,
+            onCollapse,
+        })
+
+        onToggleOpen()
+
+        expect(onCollapse).toHaveBeenCalledWith({ path })
+        expect(onExpand).toHaveBeenCalledTimes(0)
+    })
+
+    it('should set the state to open if there is an error and autoExpandLoadingError is true', () => {
+        const path = '/foo'
+        const { open } = useOpenState({
+            autoExpandLoadingError: true,
+            errorMessage: 'error message',
+            path,
+            expanded: [],
+            onExpand,
+            onCollapse,
+        })
+
+        expect(open).toBe(true)
+    })
+
+    it('should not alter the state if there is an error but autoExpandLoadingError is falsy', () => {
+        const path = '/foo'
+        const { open } = useOpenState({
+            autoExpandLoadingError: undefined,
+            errorMessage: 'error message',
+            path,
+            expanded: [],
+            onExpand,
+            onCollapse,
+        })
+
+        expect(open).toBe(false)
+    })
+
+    it('should not alter the state if autoExpandLoadingError is true but there is no error', () => {
+        const path = '/foo'
+        const { open } = useOpenState({
+            autoExpandLoadingError: true,
+            errorMessage: '',
+            path,
+            expanded: [],
+            onExpand,
+            onCollapse,
+        })
+
+        expect(open).toBe(false)
+    })
+})

--- a/src/OrganisationUnitTree/__tests__/useOrgData.test.js
+++ b/src/OrganisationUnitTree/__tests__/useOrgData.test.js
@@ -1,0 +1,68 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+
+import { addMissingDisplayNameProps, createQuery } from '../useOrgData/helpers'
+import { useOrgData } from '../useOrgData'
+
+jest.mock('@dhis2/app-runtime', () => ({
+    useDataQuery: jest.fn(() => ({ loading: false, error: null, data: {} })),
+}))
+
+jest.mock('../useOrgData/helpers', () => ({
+    createQuery: jest.fn(() => 'createQuery'),
+    addMissingDisplayNameProps: jest.fn(() => 'addMissingDisplayNameProps'),
+}))
+
+describe('OrganisationUnitTree - useOrgData', () => {
+    const ids = ['foo', 'bar', 'baz']
+
+    afterEach(() => {
+        createQuery.mockClear()
+        useDataQuery.mockClear()
+        addMissingDisplayNameProps.mockClear()
+    })
+
+    it('create the query from the ids', () => {
+        useOrgData(ids)
+        expect(createQuery).toHaveBeenCalledWith(ids)
+    })
+
+    it('should pass the created query to useDataQuery', () => {
+        createQuery.mockReturnValueOnce('foobarbaz')
+        useOrgData(ids)
+
+        const [firstArg] = useDataQuery.mock.calls[0]
+        expect(firstArg).toBe('foobarbaz')
+    })
+
+    it('should format the nodes if data is not falsy', () => {
+        const data = { id1: {} }
+        useDataQuery.mockReturnValueOnce({ loading: false, error: null, data })
+        useOrgData(ids)
+        expect(addMissingDisplayNameProps).toHaveBeenCalledWith(data)
+    })
+
+    it('should return the data from addMissingDisplayNameProps as data when there are nodes', () => {
+        const data = { id1: {} }
+        useDataQuery.mockReturnValueOnce({ loading: false, error: null, data })
+        addMissingDisplayNameProps.mockImplementationOnce(input => input)
+        const { data: actual } = useOrgData(ids)
+
+        expect(actual).toEqual(data)
+    })
+
+    it('should return the loading state from useDataQuery as loading state', () => {
+        const loading = 'foobar'
+        useDataQuery.mockReturnValueOnce({ loading, error: null, data: null })
+        const { loading: actual } = useOrgData(ids)
+
+        expect(actual).toEqual(loading)
+    })
+
+    it('should return the error state from useDataQuery as error state', () => {
+        const error = 'foobar'
+        useDataQuery.mockReturnValueOnce({ loading: false, error, data: null })
+        const { error: actual } = useOrgData(ids)
+
+        expect(actual).toEqual(error)
+    })
+})

--- a/src/OrganisationUnitTree/computeChildNodes.js
+++ b/src/OrganisationUnitTree/computeChildNodes.js
@@ -1,0 +1,35 @@
+/**
+ * @param {string[]} includedPaths
+ * @param {string} path
+ * @returns {bool}
+ */
+const isPathIncluded = (includedPaths, path) => {
+    const isIncluded = includedPaths.some(includedPath => {
+        if (path === includedPath) return true
+        return includedPath.indexOf(`${path}/`) === 0
+    })
+
+    return isIncluded
+}
+
+/**
+ * Returns all the childrenIds that should be rendered.
+ * An id will be included if it's parent's path + the id is inside
+ * the "filter" or the parent's path + id is a substring
+ * of the paths in "filter" (then it's a parent path of
+ * the units that should be included itself)
+ *
+ * @param {Object} node
+ * @param {{ id: String }[]} node.children
+ * @param {string[]} includedPaths
+ * @returns {string[]}
+ */
+export const computeChildNodes = (node, filter) => {
+    if (!filter.length) {
+        return node.children
+    }
+
+    return node.children.filter(child => {
+        return isPathIncluded(filter, `${node.path}/${child.id}`)
+    })
+}

--- a/src/OrganisationUnitTree/fromEntries.js
+++ b/src/OrganisationUnitTree/fromEntries.js
@@ -1,0 +1,8 @@
+export const fromEntries = entries =>
+    entries.reduce(
+        (collection, [key, name]) => ({
+            ...collection,
+            [key]: name,
+        }),
+        {}
+    )

--- a/src/OrganisationUnitTree/hasDescendantSelectedPaths.js
+++ b/src/OrganisationUnitTree/hasDescendantSelectedPaths.js
@@ -1,0 +1,13 @@
+/**
+ * Checks wether there are descendants of a path in the
+ * array of selected paths
+ *
+ * @param {string} path
+ * @param {string[]} selected
+ * @returns {bool}
+ */
+export const hasDescendantSelectedPaths = (path, selected) =>
+    selected.some(
+        selectedPath =>
+            selectedPath !== path && selectedPath.indexOf(path) === 0
+    )

--- a/src/OrganisationUnitTree/icons/Empty.js
+++ b/src/OrganisationUnitTree/icons/Empty.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+
+/**
+ * @module
+ * @returns {React.Component}
+ */
+export const Empty = ({ dataTest }) => (
+    <svg
+        height="18px"
+        version="1.1"
+        viewBox="0 0 18 18"
+        width="18px"
+        data-test={`${dataTest}-iconempty`}
+    >
+        <g
+            fill="none"
+            fillRule="evenodd"
+            id="icon/empty"
+            stroke="none"
+            strokeWidth="1"
+        />
+
+        <style jsx>{`
+            svg {
+                display: block;
+                margin: 3px 0;
+            }
+        `}</style>
+    </svg>
+)
+
+Empty.propTypes = {
+    dataTest: propTypes.string.isRequired,
+}

--- a/src/OrganisationUnitTree/icons/FolderClosed.js
+++ b/src/OrganisationUnitTree/icons/FolderClosed.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+
+/**
+ * @module
+ * @returns {React.Component}
+ */
+export const FolderClosed = ({ dataTest }) => (
+    <svg
+        width="18px"
+        height="18px"
+        viewBox="0 0 18 18"
+        version="1.1"
+        data-test={`${dataTest}-iconfolderclosed`}
+    >
+        <g
+            id="icon/folder/closed"
+            stroke="none"
+            strokeWidth="1"
+            fill="none"
+            fillRule="evenodd"
+        >
+            <path
+                d="M2,3.5 C1.17157288,3.5 0.5,4.17157288 0.5,5 L0.5,13 C0.5,13.8284271 1.17157288,14.5 2,14.5 L12,14.5 C12.8284271,14.5 13.5,13.8284271 13.5,13 L13.5,7 C13.5,6.17157288 12.8284271,5.5 12,5.5 L6.69098301,5.5 L5.82917961,3.7763932 C5.7444836,3.60700119 5.57135204,3.5 5.38196601,3.5 L2,3.5 Z"
+                id="Path-2"
+                stroke="#6E7A8A"
+                fill="#D5DDE5"
+            />
+        </g>
+
+        <style jsx>{`
+            svg {
+                display: block;
+                margin: 3px 0;
+            }
+        `}</style>
+    </svg>
+)
+
+FolderClosed.propTypes = {
+    dataTest: propTypes.string.isRequired,
+}

--- a/src/OrganisationUnitTree/icons/FolderOpen.js
+++ b/src/OrganisationUnitTree/icons/FolderOpen.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+
+/**
+ * @module
+ * @returns {React.Component}
+ */
+export const FolderOpen = ({ dataTest }) => (
+    <svg
+        width="18px"
+        height="18px"
+        viewBox="0 0 18 18"
+        version="1.1"
+        data-test={`${dataTest}-iconfolderopen`}
+    >
+        <g
+            id="icon/folder/open"
+            stroke="none"
+            strokeWidth="1"
+            fill="none"
+            fillRule="evenodd"
+        >
+            <g
+                id="Group"
+                transform="translate(0.000000, 3.000000)"
+                stroke="#6E7A8A"
+            >
+                <path
+                    d="M2,0.5 C1.17157288,0.5 0.5,1.17157288 0.5,2 L0.5,10 C0.5,10.8284271 1.17157288,11.5 2,11.5 L12,11.5 C12.8284271,11.5 13.5,10.8284271 13.5,10 L13.5,4 C13.5,3.17157288 12.8284271,2.5 12,2.5 L6.69098301,2.5 L5.82917961,0.776393202 C5.7444836,0.607001188 5.57135204,0.5 5.38196601,0.5 L2,0.5 Z"
+                    id="Path-2"
+                    fill="#A0ADBA"
+                />
+
+                <path
+                    d="M1.53632259,10.7093809 C1.47575089,10.7941813 1.44318932,10.8957885 1.44318932,11 C1.44318932,11.2761424 1.66704695,11.5 1.94318932,11.5 L12.4853821,11.5 C12.6468577,11.5 12.7983931,11.4220172 12.8922488,11.2906191 L16.4636774,6.2906191 C16.5242491,6.20581872 16.5568107,6.10421149 16.5568107,6 C16.5568107,5.72385763 16.3329531,5.5 16.0568107,5.5 L5.5146179,5.5 C5.35314234,5.5 5.20160692,5.57798284 5.10775116,5.7093809 L1.53632259,10.7093809 Z"
+                    id="Path-3"
+                    fill="#FBFCFD"
+                />
+            </g>
+        </g>
+
+        <style jsx>{`
+            svg {
+                margin: 3px 0;
+                display: block;
+            }
+        `}</style>
+    </svg>
+)
+
+FolderOpen.propTypes = {
+    dataTest: propTypes.string.isRequired,
+}

--- a/src/OrganisationUnitTree/icons/Single.js
+++ b/src/OrganisationUnitTree/icons/Single.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+
+/**
+ * @module
+ * @returns {React.Component}
+ */
+export const Single = ({ dataTest }) => (
+    <svg
+        height="18px"
+        version="1.1"
+        viewBox="0 0 18 18"
+        width="18px"
+        data-test={`${dataTest}-iconsingle`}
+    >
+        <g
+            fill="none"
+            fillRule="evenodd"
+            id="icon/single"
+            stroke="none"
+            strokeWidth="1"
+        >
+            <rect
+                fill="#A0ADBA"
+                height="4"
+                id="Rectangle"
+                rx="1"
+                width="4"
+                x="7"
+                y="7"
+            />
+        </g>
+
+        <style jsx>{`
+            svg {
+                display: block;
+                margin: 3px 0;
+            }
+        `}</style>
+    </svg>
+)
+
+Single.propTypes = {
+    dataTest: propTypes.string.isRequired,
+}

--- a/src/OrganisationUnitTree/propTypes.js
+++ b/src/OrganisationUnitTree/propTypes.js
@@ -1,0 +1,33 @@
+const UNIT_ID_PATTERN = '[a-zA-Z][a-zA-Z0-9]{10}'
+
+/* eslint-disable */
+export const orgUnitPathPropType = (
+    propValue,
+    key,
+    compName,
+    location,
+    propFullName
+) => {
+    if (!new RegExp(`(\/${UNIT_ID_PATTERN})+`).test(propValue[key])) {
+        return new Error(
+            `Invalid org unit path \`${propValue[key]}\` supplied to \`${compName}.${propFullName}\``
+        )
+    }
+}
+/* eslint-enable */
+
+/* eslint-disable */
+export const orgUnitIdPropType = (
+    propValue,
+    key,
+    compName,
+    location,
+    propFullName
+) => {
+    if (!new RegExp(`^${UNIT_ID_PATTERN}$`).test(propValue[key])) {
+        return new Error(
+            `Invalid org unit id \`${propValue[key]}\` supplied to \`${compName}.${propFullName}\``
+        )
+    }
+}
+/* eslint-enable */

--- a/src/OrganisationUnitTree/useExpanded.js
+++ b/src/OrganisationUnitTree/useExpanded.js
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import {
+    getInitiallyExpandedPaths,
+    createExpandHandlers,
+} from './useExpanded/helpers'
+
+/**
+ * @param {string[]} initiallyExpanded
+ * @param {Function} [onExpand]
+ * @param {Function} [onCollapse]
+ * @returns {{ expanded: string[], handleExpand: Function, handleCollapse: Function }}
+ */
+export const useExpanded = (initiallyExpanded, onExpand, onCollapse) => {
+    const allInitiallyExpandedPaths = getInitiallyExpandedPaths(
+        initiallyExpanded
+    )
+    const [expanded, setExpanded] = useState(allInitiallyExpandedPaths)
+    const { handleExpand, handleCollapse } = createExpandHandlers({
+        expanded,
+        setExpanded,
+        onExpand,
+        onCollapse,
+    })
+
+    return { expanded, handleExpand, handleCollapse }
+}

--- a/src/OrganisationUnitTree/useExpanded/__tests__/helpers.test.js
+++ b/src/OrganisationUnitTree/useExpanded/__tests__/helpers.test.js
@@ -1,0 +1,75 @@
+import { createExpandHandlers, getInitiallyExpandedPaths } from '../helpers'
+
+describe('OrganisationUnitTree - useExpanded - getInitiallyExpandedPaths', () => {
+    const initiallyExpanded = ['/foo/bar/baz', '/foobar/barbaz/bazfoo']
+
+    it('should include all initiallyExpanded paths in the returned expanded array', () => {
+        const actual = getInitiallyExpandedPaths(initiallyExpanded)
+        const expected = expect.arrayContaining(initiallyExpanded)
+        expect(actual).toEqual(expected)
+    })
+
+    it('should include all sub paths of the paths in initiallyExpanded in the returned exanded array', () => {
+        const actual = getInitiallyExpandedPaths(initiallyExpanded)
+        const expected = expect.arrayContaining([
+            '/foo',
+            '/foo/bar',
+            '/foobar',
+            '/foobar/barbaz',
+        ])
+        expect(actual).toEqual(expected)
+    })
+})
+
+describe('OrganisationUnitTree - useExpanded - createExpandHandlers', () => {
+    const initiallyExpanded = ['/foo/bar/baz', '/foobar/barbaz/bazfoo']
+    const onExpand = jest.fn()
+    const onCollapse = jest.fn()
+
+    afterEach(() => {
+        onExpand.mockClear()
+        onCollapse.mockClear()
+    })
+
+    it('should add a path to the expanded paths when calling handleExpand when not present yet', () => {
+        const setExpanded = jest.fn()
+        const expanded = initiallyExpanded
+        const { handleExpand } = createExpandHandlers({ expanded, setExpanded })
+        handleExpand({ path: '/a/new/path' })
+
+        expect(setExpanded).toHaveBeenCalledWith([...expanded, '/a/new/path'])
+    })
+
+    it('should not add a path to the expanded paths when calling handleExpand when already present', () => {
+        const setExpanded = jest.fn()
+        const expanded = [...initiallyExpanded, '/a/new/path']
+        const { handleExpand } = createExpandHandlers({ expanded, setExpanded })
+        handleExpand({ path: '/a/new/path' })
+
+        expect(setExpanded).toHaveBeenCalledTimes(0)
+    })
+
+    it('should remove a path to the expanded paths when calling handleExpand when path is expanded', () => {
+        const setExpanded = jest.fn()
+        const expanded = [...initiallyExpanded, '/a/new/path']
+        const { handleCollapse } = createExpandHandlers({
+            expanded,
+            setExpanded,
+        })
+        handleCollapse({ path: '/a/new/path' })
+
+        expect(setExpanded).toHaveBeenCalledWith(initiallyExpanded)
+    })
+
+    it('should not remove a path to the expanded paths when calling handleExpand when path is not expanded', () => {
+        const setExpanded = jest.fn()
+        const expanded = initiallyExpanded
+        const { handleCollapse } = createExpandHandlers({
+            expanded,
+            setExpanded,
+        })
+        handleCollapse({ path: '/a/new/path' })
+
+        expect(setExpanded).toHaveBeenCalledTimes(0)
+    })
+})

--- a/src/OrganisationUnitTree/useExpanded/helpers.js
+++ b/src/OrganisationUnitTree/useExpanded/helpers.js
@@ -1,0 +1,71 @@
+/**
+ * @param {string} path
+ * @returns {string[]}
+ */
+export const extractAllPathsFromPath = path => {
+    // remove leading slash and split by path delimiter/slashes
+    const segments = path.replace(/^\//, '').split('/')
+
+    const withSubPaths = segments.map((segment, index) => {
+        // take all segments from 0 to index and join them with the delimiter
+        return `/${segments.slice(0, index + 1).join('/')}`
+    })
+
+    return withSubPaths
+}
+
+/**
+ * @param {string[]} initiallyExpanded
+ * @returns {string[]}
+ */
+export const getInitiallyExpandedPaths = initiallyExpanded =>
+    initiallyExpanded.reduce((all, curPath) => {
+        const allPathsInCurPath = extractAllPathsFromPath(curPath)
+        return [...all, ...allPathsInCurPath]
+    }, [])
+
+/**
+ * @param {Object} args
+ * @param {string[]} args.expanded
+ * @param {Function} args.setExpanded
+ * @param {Function} [args.onExpand]
+ * @param {Function} [args.onCollapse]
+ * @returns {{ handleExpand: Function, handleCollapse: Function }}
+ */
+export const createExpandHandlers = ({
+    expanded,
+    setExpanded,
+    onExpand,
+    onCollapse,
+}) => {
+    const handleExpand = ({ path, ...rest }) => {
+        if (!expanded.includes(path)) {
+            setExpanded([...expanded, path])
+
+            if (onExpand) {
+                onExpand({ path, ...rest })
+            }
+        }
+    }
+
+    const handleCollapse = ({ path, ...rest }) => {
+        const pathIndex = expanded.indexOf(path)
+        if (pathIndex !== -1) {
+            const updatedExpanded =
+                pathIndex === 0
+                    ? expanded.slice(1)
+                    : [
+                          ...expanded.slice(0, pathIndex),
+                          ...expanded.slice(pathIndex + 1),
+                      ]
+
+            setExpanded(updatedExpanded)
+
+            if (onCollapse) {
+                onCollapse({ path, ...rest })
+            }
+        }
+    }
+
+    return { handleExpand, handleCollapse }
+}

--- a/src/OrganisationUnitTree/useForceReload.js
+++ b/src/OrganisationUnitTree/useForceReload.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * This will create a new reloadId everytime "forceReload" changes to true,
+ * which can be used as the "key" prop on the org unit tree.
+ * When that id changes, the whole tree rerenders
+ * and therefore triggers all "useDataQuery"s to
+ * run the query again
+ *
+ * @param {bool} forceReload
+ * @returns {Int}
+ */
+export const useForceReload = forceReload => {
+    const [reloadId, setReloadId] = useState(0)
+
+    useEffect(() => {
+        forceReload === true && setReloadId(reloadId + 1)
+    }, [forceReload])
+
+    return reloadId
+}

--- a/src/OrganisationUnitTree/useOpenState.js
+++ b/src/OrganisationUnitTree/useOpenState.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * @param {Object} args
+ * @param {string} args.path
+ * @param {string} [args.errorMessage]
+ * @param {string} [args.autoExpandLoadingError]
+ * @param {string[]} args.expanded
+ * @param {Function} [args.onExpand]
+ * @param {Function} [args.onCollapse]
+ * @returns {Object}
+ */
+export const useOpenState = ({
+    path,
+    expanded,
+    onExpand,
+    onCollapse,
+    errorMessage,
+    autoExpandLoadingError,
+}) => {
+    const autoExpand = autoExpandLoadingError && !!errorMessage
+    const [openedOnceDueToError, setOpenedOnce] = useState(!!errorMessage)
+    const [open, setOpen] = useState(autoExpand || expanded.includes(path))
+
+    useEffect(() => {
+        if (autoExpand && !openedOnceDueToError) {
+            setOpen(true)
+            setOpenedOnce(true)
+        }
+    }, [autoExpand, openedOnceDueToError])
+
+    const onToggleOpen = () => {
+        const newOpen = !open
+        const payload = { path }
+
+        setOpen(newOpen)
+
+        if (onExpand && newOpen) {
+            onExpand(payload)
+        } else if (onCollapse && !newOpen) {
+            onCollapse(payload)
+        }
+    }
+
+    return { open, onToggleOpen }
+}

--- a/src/OrganisationUnitTree/useOrgData.js
+++ b/src/OrganisationUnitTree/useOrgData.js
@@ -1,0 +1,22 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+
+import { addMissingDisplayNameProps, createQuery } from './useOrgData/helpers'
+
+/**
+ * @param {string[]} ids
+ * @param {Object} [options]
+ * @param {boolean} [options.withChildren]
+ * @param {boolean} [options.isUserDataViewFallback]
+ * @returns {Object}
+ */
+export const useOrgData = (
+    ids,
+    { withChildren = true, isUserDataViewFallback } = {}
+) => {
+    const query = createQuery(ids)
+    const variables = { withChildren, isUserDataViewFallback }
+    const { loading, error, data, refetch } = useDataQuery(query, { variables })
+    const nodes = data ? addMissingDisplayNameProps(data) : {}
+
+    return { loading, error, data: nodes, refetch }
+}

--- a/src/OrganisationUnitTree/useOrgData/__tests__/helpers.test.js
+++ b/src/OrganisationUnitTree/useOrgData/__tests__/helpers.test.js
@@ -1,0 +1,106 @@
+import {
+    createOrgUnitQuery,
+    createQuery,
+    addMissingDisplayNameProps,
+} from '../helpers'
+
+describe('OrganisationUnitTree - createOrgUnitQuery', () => {
+    it('should create a query resource object with the id in the resource url for an id', () => {
+        const id = 'foo'
+        const actual = createOrgUnitQuery(id)
+        const expected = expect.objectContaining({
+            resource: `organisationUnits/foo`,
+        })
+
+        expect(actual).toEqual(expected)
+    })
+
+    it('should load the displayName, path and children with their path, displayName, childrenIds and id', () => {
+        const variables = { withChildren: true }
+        const actual = createOrgUnitQuery('foo', variables)
+        const params = actual.params(variables)
+        const expected = expect.objectContaining({
+            params: expect.objectContaining({
+                fields: 'children[path,displayName,id],displayName,path,id',
+            }),
+        })
+
+        expect({ ...actual, params }).toEqual(expected)
+    })
+
+    it('should load the displayName, path and id', () => {
+        const variables = { withChildren: false }
+        const actual = createOrgUnitQuery('foo', variables)
+        const params = actual.params(variables)
+        const expected = expect.objectContaining({
+            params: expect.objectContaining({
+                fields: 'displayName,path,id',
+            }),
+        })
+
+        expect({ ...actual, params }).toEqual(expected)
+    })
+
+    it('should send the isUserDataViewFallback parameter', () => {
+        const variables = { isUserDataViewFallback: true }
+        const actual = createOrgUnitQuery('foo', variables)
+        const params = actual.params(variables)
+        const expected = expect.objectContaining({
+            params: expect.objectContaining({
+                isUserDataViewFallback: true,
+            }),
+        })
+
+        expect({ ...actual, params }).toEqual(expected)
+    })
+
+    it('should load without pagination', () => {
+        const actual = createOrgUnitQuery('foo')
+        const params = actual.params({})
+        const expected = expect.objectContaining({
+            params: expect.objectContaining({
+                paging: false,
+            }),
+        })
+
+        expect({ ...actual, params }).toEqual(expected)
+    })
+})
+
+describe('OrganisationUnitTree - createQuery', () => {
+    it('should create an object with a query for each id', () => {
+        const id1 = 'foo'
+        const id2 = 'bar'
+        const id1Query = createOrgUnitQuery(id1)
+        const id2Query = createOrgUnitQuery(id2)
+        const ids = [id1, id2]
+
+        const actual = JSON.stringify(createQuery(ids))
+        const expected = JSON.stringify({ foo: id1Query, bar: id2Query })
+
+        expect(actual).toEqual(expected)
+    })
+})
+
+describe('OrganisationUnitTree - addMissingDisplayNameProps', () => {
+    it('should add an empty string as displayName if the prop is falsy', () => {
+        const nodes = {
+            id1: { noDisplayName: 'foo' },
+            id2: { displayName: null },
+            id3: { displayName: false },
+            id4: { displayName: undefined },
+            id5: { displayName: 'Should stay the same' },
+        }
+
+        const actual = addMissingDisplayNameProps(nodes)
+        const expected = {
+            id1: { noDisplayName: 'foo', displayName: '' },
+            id2: { displayName: '' },
+            id3: { displayName: '' },
+            id4: { displayName: '' },
+            id5: { displayName: 'Should stay the same' },
+        }
+
+        expect(actual).toEqual(expected)
+    })
+})

--- a/src/OrganisationUnitTree/useOrgData/helpers.js
+++ b/src/OrganisationUnitTree/useOrgData/helpers.js
@@ -1,0 +1,30 @@
+import { fromEntries } from '../fromEntries'
+
+const withChildrenFields = 'children[path,displayName,id],displayName,path,id'
+const withoutChildrenFields = 'displayName,path,id'
+
+export const createOrgUnitQuery = id => ({
+    resource: `organisationUnits/${id}`,
+    params: ({ withChildren, isUserDataViewFallback }) => ({
+        isUserDataViewFallback,
+        fields: withChildren ? withChildrenFields : withoutChildrenFields,
+        paging: false,
+    }),
+})
+
+export const createQuery = ids =>
+    ids.reduce((query, id) => ({ ...query, [id]: createOrgUnitQuery(id) }), {})
+
+/**
+ * @param {Object.<string, Object>[]} nodes
+ * @returns {}
+ */
+export const addMissingDisplayNameProps = nodes => {
+    const nodeEntries = Object.entries(nodes)
+    const nodesWithDisplayName = nodeEntries.map(([id, node]) => {
+        const displayName = node.displayName || ''
+        return [id, { ...node, displayName }]
+    })
+
+    return fromEntries(nodesWithDisplayName)
+}

--- a/src/__demo__/OrganisationUnitTree.stories.js
+++ b/src/__demo__/OrganisationUnitTree.stories.js
@@ -1,0 +1,452 @@
+/* eslint-disable react/no-unescaped-entities,react/prop-types */
+import React, { useEffect, useState } from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../index'
+import { CustomDataProvider, DataProvider } from '@dhis2/app-runtime'
+
+const log = true
+const onChange = (...args) => log && console.log('onChange', ...args)
+const onExpand = (...args) => log && console.log('onExpand', ...args)
+const onCollapse = (...args) => log && console.log('onCollapse', ...args)
+const onChildrenLoaded = (...args) =>
+    log && console.log('onChildrenLoaded', ...args)
+
+const customData = {
+    'organisationUnits/A0000000000': () =>
+        new Promise(resolve => {
+            setTimeout(() => {
+                resolve({
+                    id: 'A0000000000',
+                    path: '/A0000000000',
+                    displayName: 'Org Unit 1',
+                    children: [
+                        {
+                            id: 'A0000000001',
+                            path: '/A0000000000/A0000000001',
+                            children: [
+                                { id: 'A0000000003' },
+                                { id: 'A0000000004' },
+                            ],
+                            displayName: 'Org Unit 2',
+                        },
+                        {
+                            id: 'A0000000002',
+                            path: '/A0000000000/A0000000002',
+                            children: [],
+                            displayName: 'Org Unit 3',
+                        },
+                        {
+                            id: 'A0000000006',
+                            path: '/A0000000000/A0000000006',
+                            children: [],
+                            displayName: 'Org Unit 7',
+                        },
+                    ],
+                })
+            }, 1000)
+        }),
+    'organisationUnits/A0000000001': () =>
+        new Promise(resolve => {
+            setTimeout(() => {
+                resolve({
+                    id: 'A0000000001',
+                    path: '/A0000000000/A0000000001',
+                    displayName: 'Org Unit 2',
+                    children: [
+                        {
+                            id: 'A0000000003',
+                            path: '/A0000000000/A0000000001/A0000000003',
+                            children: [],
+                            displayName: 'Org Unit 4',
+                        },
+                        {
+                            id: 'A0000000004',
+                            path: '/A0000000000/A0000000001/A0000000004',
+                            children: [],
+                            displayName: 'Org Unit 5',
+                        },
+                    ],
+                })
+            }, 1000)
+        }),
+    'organisationUnits/A0000000002': {
+        displayName: 'Org Unit 3',
+        id: 'A0000000002',
+        path: '/A0000000000/A0000000002',
+        children: [],
+    },
+    'organisationUnits/A0000000003': {
+        displayName: 'Org Unit 4',
+        id: 'A0000000003',
+        path: '/A0000000000/A0000000001/A0000000003',
+        children: [],
+    },
+    'organisationUnits/A0000000004': {
+        displayName: 'Org Unit 5',
+        id: 'A0000000004',
+        path: '/A0000000000/A0000000001/A0000000004',
+        children: [],
+    },
+    'organisationUnits/A0000000006': () =>
+        new Promise(resolve => {
+            setTimeout(() => {
+                resolve({
+                    displayName: 'Org Unit 7',
+                    id: 'A0000000006',
+                    path: '/A0000000000/A0000000006',
+                    children: [],
+                })
+            }, 400)
+        }),
+}
+
+const ForceReloadAll = ({ delay }) => {
+    const [forceReload, setForceReload] = useState(false)
+
+    useEffect(() => {
+        setTimeout(() => setForceReload(true), delay)
+    }, [])
+
+    return (
+        <OrganisationUnitTree
+            onChange={onChange}
+            forceReload={forceReload}
+            name="Root org unit"
+            roots={['A0000000000']}
+            initiallyExpanded={['/A0000000000/A0000000001']}
+            selected={['/A0000000000/A0000000001/A0000000003']}
+        />
+    )
+}
+
+const ForceReloadIds = () => {
+    return (
+        <p>
+            This is currently not working due to limitations of the data engine
+            in the app runtime.
+        </p>
+    )
+
+    //const [idsThatShouldBeReloaded, setIdsThatShouldBeReloaded] = useState([])
+
+    //useEffect(() => {
+    //    setTimeout(() => setIdsThatShouldBeReloaded(['A0000000001']), delay)
+    //}, [])
+
+    //return (
+    //    <OrganisationUnitTree
+    //        onChange={onChange}
+    //        idsThatShouldBeReloaded={idsThatShouldBeReloaded}
+    //        name="Root org unit"
+    //        roots={['A0000000000']}
+    //        initiallyExpanded={['/A0000000000', '/A0000000000/A0000000001']}
+    //        selected={['/A0000000000/A0000000001/A0000000003']}
+    //        onChildrenLoaded={({ path, forced }) =>
+    //            console.log(
+    //                `Unit with path "${path}" loaded, was forced: ${
+    //                    forced ? 'yes' : 'no'
+    //                }`
+    //            )
+    //        }
+    //    />
+    //)
+}
+
+const ReplaceRoots = ({ delay }) => {
+    return (
+        <p>
+            This is currently not working due to limitations of the data engine
+            in the app runtime. Normally the root unit would've been replaced
+            after {` ${delay} `} milliseconds.
+        </p>
+    )
+
+    //const [roots, setRoots] = useState(['A0000000000'])
+
+    //useEffect(() => {
+    //    setTimeout(() => setRoots(['A0000000001']), delay)
+    //}, [])
+
+    //return (
+    //    <OrganisationUnitTree
+    //        name="Root org unit"
+    //        roots={roots}
+    //        onChange={console.log.bind(null, 'onChange')}
+    //        initiallyExpanded={['/A0000000001']}
+    //    />
+    //)
+}
+
+storiesOf('OrganisationUnitTree', module)
+    .addDecorator(fn => (
+        <CustomDataProvider data={customData}>{fn()}</CustomDataProvider>
+    ))
+    .add('Collapsed', () => (
+        <OrganisationUnitTree
+            onChange={onChange}
+            name="Root org unit"
+            roots={['A0000000000']}
+        />
+    ))
+    .add('Expanded', () => (
+        <OrganisationUnitTree
+            onChange={onChange}
+            name="Root org unit"
+            roots={['A0000000000']}
+            initiallyExpanded={['/A0000000000/A0000000001']}
+        />
+    ))
+    .add('Multiple roots', () => (
+        <OrganisationUnitTree
+            onChange={onChange}
+            name="Root org unit"
+            roots={['A0000000000', 'A0000000001']}
+            initiallyExpanded={['/A0000000000/A0000000001']}
+        />
+    ))
+    .add('Filtered (root)', () => (
+        <OrganisationUnitTree
+            onChange={onChange}
+            name="Root org unit"
+            roots={['A0000000000', 'A0000000001']}
+            initiallyExpanded={['/A0000000000/A0000000001']}
+            filter={['/A0000000000']}
+        />
+    ))
+    .add('Filtered', () => (
+        <OrganisationUnitTree
+            onChange={onChange}
+            name="Root org unit"
+            roots={['A0000000000']}
+            initiallyExpanded={['/A0000000000/A0000000001']}
+            filter={['/A0000000000/A0000000001']}
+        />
+    ))
+    .add('Selected multiple', () => (
+        <OrganisationUnitTree
+            onChange={onChange}
+            name="Root org unit"
+            roots={['A0000000000']}
+            selected={[
+                '/A0000000000/A0000000002',
+                '/A0000000000/A0000000001/A0000000003',
+            ]}
+            initiallyExpanded={['/A0000000000', '/A0000000000/A0000000001']}
+        />
+    ))
+    .add('Indeterminate', () => (
+        <OrganisationUnitTree
+            onChange={onChange}
+            name="Root org unit"
+            roots={['A0000000000']}
+            selected={['/A0000000000/A0000000001']}
+            initiallyExpanded={['/A0000000000']}
+        />
+    ))
+    .add('Single selection', () => (
+        <OrganisationUnitTree
+            onChange={onChange}
+            singleSelection
+            name="Root org unit"
+            roots={['A0000000000']}
+            selected={['/A0000000000/A0000000001']}
+            initiallyExpanded={['/A0000000000']}
+        />
+    ))
+    .add('No selection', () => (
+        <OrganisationUnitTree
+            onChange={onChange}
+            disableSelection
+            name="Root org unit"
+            roots={['A0000000000']}
+            selected={['/A0000000000/A0000000001']}
+            initiallyExpanded={['/A0000000000']}
+        />
+    ))
+    .add('Highlighted', () => (
+        <OrganisationUnitTree
+            onChange={onChange}
+            highlighted={['/A0000000000/A0000000001']}
+            name="Root org unit"
+            roots={['A0000000000']}
+            initiallyExpanded={['/A0000000000']}
+        />
+    ))
+    .add('Force reload all', () => <ForceReloadAll delay={2000} />)
+    .add('Force reload one unit', () => <ForceReloadIds delay={2000} />)
+    .add('Replace roots', () => <ReplaceRoots delay={1000} />)
+
+storiesOf('OrganisationUnitTree', module).add('Loading', () => (
+    <CustomDataProvider
+        data={{
+            ...customData,
+            'organisationUnits/A0000000001': () => new Promise(() => null),
+        }}
+    >
+        <OrganisationUnitTree
+            onChange={onChange}
+            name="Root org unit"
+            roots={['A0000000000']}
+            initiallyExpanded={['/A0000000000/A0000000001']}
+        />
+    </CustomDataProvider>
+))
+
+storiesOf('OrganisationUnitTree', module).add('Root loading', () => (
+    <CustomDataProvider
+        data={{
+            ...customData,
+            'organisationUnits/A0000000000': () => new Promise(() => null),
+        }}
+    >
+        <fieldset style={{ maxWidth: 600 }}>
+            <legend style={{ padding: '0 10px' }}>
+                Custom container (max-width: 600px)
+            </legend>
+            <OrganisationUnitTree
+                onChange={onChange}
+                name="Root org unit"
+                roots={['A0000000000']}
+                initiallyExpanded={['/A0000000000/A0000000001']}
+            />
+        </fieldset>
+    </CustomDataProvider>
+))
+
+storiesOf('OrganisationUnitTree', module).add('Root error', () => (
+    <CustomDataProvider
+        data={{
+            ...customData,
+            'organisationUnits/A0000000000': () =>
+                new Promise((_, reject) =>
+                    reject(
+                        'This is a custom error message, it could be anything'
+                    )
+                ),
+        }}
+    >
+        <fieldset style={{ maxWidth: 600 }}>
+            <legend style={{ padding: '0 10px' }}>
+                Custom container (max-width: 600px)
+            </legend>
+            <OrganisationUnitTree
+                onChange={onChange}
+                name="Root org unit"
+                roots={['A0000000000']}
+                initiallyExpanded={['/A0000000000/A0000000001']}
+            />
+        </fieldset>
+    </CustomDataProvider>
+))
+
+storiesOf('OrganisationUnitTree', module).add(
+    'Loading error grandchild',
+    () => (
+        <CustomDataProvider
+            data={{
+                ...customData,
+                'organisationUnits/A0000000003': () =>
+                    Promise.reject(
+                        new Error('Loading org unit 4 and 5 failed')
+                    ),
+            }}
+        >
+            <OrganisationUnitTree
+                autoExpandLoadingError
+                name="Root org unit"
+                roots={['A0000000000']}
+                onChange={onChange}
+                onExpand={onExpand}
+                onCollapse={onCollapse}
+                onChildrenLoaded={onChildrenLoaded}
+                initiallyExpanded={['/A0000000000/A0000000001']}
+            />
+        </CustomDataProvider>
+    )
+)
+
+const DX_onChange = (selected, setSelected, singleSelection) => ({
+    id,
+    path,
+    checked,
+}) => {
+    console.log('onChange', { path, id, checked })
+    const pathIndex = selected.indexOf(path)
+
+    if (checked) {
+        setSelected(singleSelection ? [path] : [...selected, path])
+    } else {
+        setSelected(
+            singleSelection
+                ? []
+                : [
+                      ...selected.slice(0, pathIndex),
+                      ...selected.slice(pathIndex + 1),
+                  ]
+        )
+    }
+}
+
+const Wrapper = props => {
+    const [selected, setSelected] = useState([])
+
+    return (
+        <OrganisationUnitTree
+            name="Root org unit"
+            roots={['A0000000000']}
+            selected={selected}
+            onChange={DX_onChange(selected, setSelected, props.singleSelection)}
+            initiallyExpanded={['A0000000001/A0000000002']}
+            {...props}
+        />
+    )
+}
+
+storiesOf('OrganisationUnitTree', module)
+    .addDecorator(fn => (
+        <CustomDataProvider data={customData}>{fn()}</CustomDataProvider>
+    ))
+    .add('DX: Multi selection', () => <Wrapper />)
+    .add('DX: Single selection', () => <Wrapper singleSelection />)
+    .add('DX: No selection', () => <Wrapper disableSelection />)
+
+storiesOf('OrganisationUnitTree', module)
+    .addDecorator(fn => (
+        <DataProvider baseUrl="https://debug.dhis2.org/dev" apiVersion="">
+            {fn()}
+        </DataProvider>
+    ))
+    .add('DX: With real backend', () => (
+        <div>
+            <div style={{ marginBottom: 20, lineHeight: '28px' }}>
+                <b>
+                    This story doesn't work on netlify for some reason, just run
+                    it locally.
+                </b>
+                <br />
+                You need to log in to{' '}
+                <a
+                    href="https://debug.dhis2.org/dev"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    https://debug.dhis2.org/dev
+                </a>
+                <br />
+                Make sure the{' '}
+                <code style={{ background: '#ccc' }}>localhost:[PORT]</code> is
+                part of the accepted list:{' '}
+                <a
+                    href="https://debug.dhis2.org/dev/dhis-web-settings/#/access"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Settings app / Access
+                </a>
+            </div>
+            <Wrapper
+                //initiallyExpanded={['/ImspTQPwCqd/eIQbndfxQMb']}
+                roots="ImspTQPwCqd"
+            />
+        </div>
+    ))

--- a/src/__e2e__/OrganisationUnitTree/children_as_child_nodes.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/children_as_child_nodes.stories.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    namespace,
+} from './common'
+
+storiesOf(namespace, module).add('Closed with children', () => (
+    <CustomDataProvider data={dataProviderData}>
+        <StatefulMultiSelectionWrapper>
+            {({ selected, onChange }) => (
+                <OrganisationUnitTree
+                    roots="A0000000000"
+                    onChange={onChange}
+                    selected={selected}
+                />
+            )}
+        </StatefulMultiSelectionWrapper>
+    </CustomDataProvider>
+))

--- a/src/__e2e__/OrganisationUnitTree/common.js
+++ b/src/__e2e__/OrganisationUnitTree/common.js
@@ -1,0 +1,111 @@
+import React, { useState } from 'react'
+import propTypes from '@dhis2/prop-types'
+
+export const namespace = 'OrganisationUnitTree'
+
+export const delayResponse = (delay, response) => () =>
+    new Promise(resolve => setTimeout(() => resolve(response), delay))
+
+export const dataProviderData = {
+    'organisationUnits/A0000000000': {
+        id: 'A0000000000',
+        path: '/A0000000000',
+        displayName: 'Org Unit 1',
+        children: [
+            {
+                id: 'A0000000001',
+                path: '/A0000000000/A0000000001',
+                children: [{ id: 'A0000000003' }, { id: 'A0000000004' }],
+                displayName: 'Org Unit 2',
+            },
+            {
+                id: 'A0000000002',
+                path: '/A0000000000/A0000000002',
+                children: [],
+                displayName: 'Org Unit 3',
+            },
+            {
+                id: 'A0000000006',
+                path: '/A0000000000/A0000000006',
+                children: [],
+                displayName: 'Org Unit 7',
+            },
+        ],
+    },
+    'organisationUnits/A0000000001': {
+        id: 'A0000000001',
+        path: '/A0000000000/A0000000001',
+        displayName: 'Org Unit 2',
+        children: [
+            {
+                id: 'A0000000003',
+                path: '/A0000000000/A0000000001/A0000000003',
+                children: [],
+                displayName: 'Org Unit 4',
+            },
+            {
+                id: 'A0000000004',
+                path: '/A0000000000/A0000000001/A0000000004',
+                children: [],
+                displayName: 'Org Unit 5',
+            },
+        ],
+    },
+    'organisationUnits/A0000000002': {
+        displayName: 'Org Unit 3',
+        id: 'A0000000002',
+        path: '/A0000000000/A0000000002',
+        children: [],
+    },
+    'organisationUnits/A0000000003': {
+        displayName: 'Org Unit 4',
+        id: 'A0000000003',
+        path: '/A0000000000/A0000000001/A0000000003',
+        children: [],
+    },
+    'organisationUnits/A0000000004': {
+        displayName: 'Org Unit 5',
+        id: 'A0000000004',
+        path: '/A0000000000/A0000000001/A0000000004',
+        children: [],
+    },
+    'organisationUnits/A0000000006': {
+        displayName: 'Org Unit 7',
+        id: 'A0000000006',
+        path: '/A0000000000/A0000000006',
+        children: [],
+    },
+}
+
+const onChange = (selected, setSelected) => ({ selected: newSelected }) => {
+    setSelected(newSelected)
+    return newSelected
+}
+
+export const StatefulMultiSelectionWrapper = ({
+    children,
+    onSelectionChange,
+}) => {
+    const [selected, setSelected] = useState([])
+    const onChangeHandler = onChange(selected, setSelected, false)
+
+    return (
+        <>
+            {children({
+                selected,
+                onChange: (...args) => {
+                    const newSelection = onChangeHandler(...args)
+
+                    if (onSelectionChange) {
+                        onSelectionChange(newSelection)
+                    }
+                },
+            })}
+        </>
+    )
+}
+
+StatefulMultiSelectionWrapper.propTypes = {
+    children: propTypes.func.isRequired,
+    onSelectionChange: propTypes.func,
+}

--- a/src/__e2e__/OrganisationUnitTree/displaying_loading_error.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/displaying_loading_error.stories.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    namespace,
+} from './common'
+
+const dataPriverDataWithError = {
+    ...dataProviderData,
+    'organisationUnits/A0000000001': () => {
+        return new Promise((resolve, reject) =>
+            setTimeout(() => {
+                reject(new Error('Foobar custom error message'))
+            }, 100)
+        )
+    },
+}
+
+storiesOf(namespace, module)
+    .add('A0000000001 loading error', () => (
+        <CustomDataProvider data={dataPriverDataWithError}>
+            <StatefulMultiSelectionWrapper>
+                {() => (
+                    <OrganisationUnitTree
+                        roots="A0000000000"
+                        onChange={() => null}
+                    />
+                )}
+            </StatefulMultiSelectionWrapper>
+        </CustomDataProvider>
+    ))
+    .add('A0000000001 loading error autoexpand', () => (
+        <CustomDataProvider data={dataPriverDataWithError}>
+            <StatefulMultiSelectionWrapper>
+                {() => (
+                    <OrganisationUnitTree
+                        autoExpandLoadingError
+                        roots="A0000000000"
+                        onChange={() => null}
+                    />
+                )}
+            </StatefulMultiSelectionWrapper>
+        </CustomDataProvider>
+    ))

--- a/src/__e2e__/OrganisationUnitTree/force_reload.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/force_reload.stories.js
@@ -1,0 +1,56 @@
+import { Button } from '@dhis2/ui-core'
+import React, { useState } from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    delayResponse,
+    namespace,
+} from './common'
+
+const afterReloadData = {
+    'organisationUnits/A0000000000': delayResponse(
+        1000,
+        dataProviderData['organisationUnits/A0000000000']
+    ),
+    'organisationUnits/A0000000001': delayResponse(
+        2000,
+        dataProviderData['organisationUnits/A0000000001']
+    ),
+}
+
+const ForceReloading = () => {
+    const [forceReload, setForceReload] = useState(false)
+
+    return (
+        <CustomDataProvider data={afterReloadData}>
+            <Button
+                disabled={forceReload}
+                dataTest="reload-all"
+                onClick={() => setForceReload(true)}
+            >
+                Force reload tree
+            </Button>
+
+            <StatefulMultiSelectionWrapper>
+                {({ selected, onChange }) => (
+                    <OrganisationUnitTree
+                        roots="A0000000000"
+                        onChange={onChange}
+                        selected={selected}
+                        forceReload={forceReload}
+                        onChildrenLoaded={data => {
+                            if (data.A0000000000) {
+                                setForceReload(false)
+                            }
+                        }}
+                    />
+                )}
+            </StatefulMultiSelectionWrapper>
+        </CustomDataProvider>
+    )
+}
+
+storiesOf(namespace, module).add('Force reloading', () => <ForceReloading />)

--- a/src/__e2e__/OrganisationUnitTree/highlight.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/highlight.stories.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    namespace,
+} from './common'
+
+storiesOf(namespace, module).add('Root highlighted', () => (
+    <CustomDataProvider data={dataProviderData}>
+        <StatefulMultiSelectionWrapper>
+            {({ onChange }) => (
+                <OrganisationUnitTree
+                    roots="A0000000000"
+                    onChange={onChange}
+                    highlighted={['/A0000000000']}
+                />
+            )}
+        </StatefulMultiSelectionWrapper>
+    </CustomDataProvider>
+))

--- a/src/__e2e__/OrganisationUnitTree/initially_expanded.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/initially_expanded.stories.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    namespace,
+} from './common'
+
+storiesOf(namespace, module)
+    .add('No initially expanded paths', () => (
+        <CustomDataProvider data={dataProviderData}>
+            <StatefulMultiSelectionWrapper>
+                {({ onChange }) => (
+                    <OrganisationUnitTree
+                        roots="A0000000000"
+                        onChange={onChange}
+                    />
+                )}
+            </StatefulMultiSelectionWrapper>
+        </CustomDataProvider>
+    ))
+    .add('initially expanded paths', () => (
+        <CustomDataProvider data={dataProviderData}>
+            <StatefulMultiSelectionWrapper>
+                {({ onChange }) => (
+                    <OrganisationUnitTree
+                        roots="A0000000000"
+                        onChange={onChange}
+                        initiallyExpanded={['/A0000000000']}
+                    />
+                )}
+            </StatefulMultiSelectionWrapper>
+        </CustomDataProvider>
+    ))

--- a/src/__e2e__/OrganisationUnitTree/loading_state.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/loading_state.stories.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    namespace,
+} from './common'
+
+const data = {
+    'organisationUnits/A0000000000':
+        dataProviderData['organisationUnits/A0000000000'],
+    'organisationUnits/A0000000001': new Promise(() => {}),
+    'organisationUnits/A0000000002': new Promise(() => {}),
+    'organisationUnits/A0000000006': new Promise(() => {}),
+}
+
+storiesOf(namespace, module).add('A0000000001 loading', () => (
+    <CustomDataProvider data={data}>
+        <StatefulMultiSelectionWrapper>
+            {({ onChange }) => (
+                <OrganisationUnitTree roots="A0000000000" onChange={onChange} />
+            )}
+        </StatefulMultiSelectionWrapper>
+    </CustomDataProvider>
+))

--- a/src/__e2e__/OrganisationUnitTree/multi_selection.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/multi_selection.stories.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    namespace,
+} from './common'
+
+window.selection = []
+
+storiesOf(namespace, module).add('Multiple selection', () => (
+    <CustomDataProvider data={dataProviderData}>
+        <StatefulMultiSelectionWrapper
+            onSelectionChange={newSelection =>
+                (window.selection = newSelection)
+            }
+        >
+            {({ selected, onChange }) => (
+                <OrganisationUnitTree
+                    roots="A0000000000"
+                    onChange={onChange}
+                    selected={selected}
+                />
+            )}
+        </StatefulMultiSelectionWrapper>
+    </CustomDataProvider>
+))

--- a/src/__e2e__/OrganisationUnitTree/no_selection.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/no_selection.stories.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    namespace,
+} from './common'
+
+storiesOf(namespace, module)
+    .add('No selection closed', () => (
+        <CustomDataProvider data={dataProviderData}>
+            <StatefulMultiSelectionWrapper>
+                {({ onChange }) => (
+                    <OrganisationUnitTree
+                        disableSelection
+                        roots="A0000000000"
+                        onChange={onChange}
+                    />
+                )}
+            </StatefulMultiSelectionWrapper>
+        </CustomDataProvider>
+    ))
+    .add('No selection root opened', () => (
+        <CustomDataProvider data={dataProviderData}>
+            <StatefulMultiSelectionWrapper>
+                {({ onChange }) => (
+                    <OrganisationUnitTree
+                        disableSelection
+                        roots="A0000000000"
+                        onChange={onChange}
+                        initiallyExpanded={['/A0000000000']}
+                    />
+                )}
+            </StatefulMultiSelectionWrapper>
+        </CustomDataProvider>
+    ))

--- a/src/__e2e__/OrganisationUnitTree/path_based_filtering.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/path_based_filtering.stories.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    namespace,
+} from './common'
+
+window.dataProviderData = dataProviderData
+
+storiesOf(namespace, module)
+    .add('Filtered by 3-level-path', () => (
+        <CustomDataProvider data={dataProviderData}>
+            <StatefulMultiSelectionWrapper>
+                {({ onChange }) => (
+                    <OrganisationUnitTree
+                        roots="A0000000000"
+                        onChange={onChange}
+                        initiallyExpanded={[
+                            '/A0000000000',
+                            '/A0000000000/A0000000001',
+                            '/A0000000000/A0000000002',
+                        ]}
+                        filter={['/A0000000000/A0000000001/A0000000003']}
+                    />
+                )}
+            </StatefulMultiSelectionWrapper>
+        </CustomDataProvider>
+    ))
+    .add('Filtered by 3-level-path and 2-level-path', () => (
+        <CustomDataProvider data={dataProviderData}>
+            <StatefulMultiSelectionWrapper>
+                {({ onChange }) => (
+                    <OrganisationUnitTree
+                        roots="A0000000000"
+                        onChange={onChange}
+                        initiallyExpanded={[
+                            '/A0000000000',
+                            '/A0000000000/A0000000001',
+                            '/A0000000000/A0000000002',
+                        ]}
+                        filter={[
+                            '/A0000000000/A0000000001/A0000000003',
+                            '/A0000000000/A0000000002',
+                        ]}
+                    />
+                )}
+            </StatefulMultiSelectionWrapper>
+        </CustomDataProvider>
+    ))

--- a/src/__e2e__/OrganisationUnitTree/single_selection.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/single_selection.stories.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    namespace,
+} from './common'
+
+const data = {
+    'organisationUnits/A0000000000': {
+        ...dataProviderData['organisationUnits/A0000000000'],
+        children: [],
+    },
+    'organisationUnits/A0000000001': {
+        ...dataProviderData['organisationUnits/A0000000001'],
+        path: '/A0000000001',
+        children: [],
+    },
+}
+
+storiesOf(namespace, module).add('Single selection', () => (
+    <CustomDataProvider data={data}>
+        <StatefulMultiSelectionWrapper>
+            {({ selected, onChange }) => (
+                <OrganisationUnitTree
+                    singleSelection
+                    roots={['A0000000000', 'A0000000001']}
+                    onChange={onChange}
+                    selected={selected}
+                />
+            )}
+        </StatefulMultiSelectionWrapper>
+    </CustomDataProvider>
+))

--- a/src/__e2e__/OrganisationUnitTree/tree_api.stories.js
+++ b/src/__e2e__/OrganisationUnitTree/tree_api.stories.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { OrganisationUnitTree } from '../../index'
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import {
+    StatefulMultiSelectionWrapper,
+    dataProviderData,
+    namespace,
+} from './common'
+
+window.dataProviderData = {
+    'organisationUnits/A0000000000': {
+        ...dataProviderData['organisationUnits/A0000000000'],
+        children: [
+            dataProviderData['organisationUnits/A0000000000'].children[0],
+        ],
+    },
+    'organisationUnits/A0000000001': {
+        ...dataProviderData['organisationUnits/A0000000000'],
+        children: [],
+    },
+}
+window.onChange = window.Cypress && window.Cypress.cy.stub()
+window.onCollapse = window.Cypress && window.Cypress.cy.stub()
+window.onExpand = window.Cypress && window.Cypress.cy.stub()
+window.onChildrenLoaded = window.Cypress && window.Cypress.cy.stub()
+
+storiesOf(namespace, module).add('Events', () => (
+    <CustomDataProvider data={window.dataProviderData}>
+        <StatefulMultiSelectionWrapper>
+            {({ selected, onChange }) => (
+                <OrganisationUnitTree
+                    roots="A0000000000"
+                    selected={selected}
+                    onChange={(...args) => {
+                        onChange(...args)
+                        window.onChange(...args)
+                    }}
+                    onExpand={window.onExpand}
+                    onCollapse={window.onCollapse}
+                    onChildrenLoaded={window.onChildrenLoaded}
+                />
+            )}
+        </StatefulMultiSelectionWrapper>
+    </CustomDataProvider>
+))

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export { HeaderBar } from './HeaderBar'
+export { OrganisationUnitTree } from './OrganisationUnitTree'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,7 +1536,7 @@
     "@dhis2/ui-widgets" "^2.0.4"
     moment "^2.24.0"
 
-"@dhis2/app-runtime@^2", "@dhis2/app-runtime@^2.0.4":
+"@dhis2/app-runtime@^2.0.4", "@dhis2/app-runtime@^2.1":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.1.0.tgz#4aa9192183477abb98f7eb3d58bec5b4d5786b44"
   integrity sha512-msWbIjnr01PWSBTfSuIqb71chaiy7Z1Xg2G11Ib/3X3QJyEJ5tuXhmkTXRHGJFkeZv+QfiMl7tHGxJewwSZb+g==
@@ -16492,7 +16492,7 @@ w3c-xmlserializer@^1.1.2:
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
 
-wait-on@^4.0.1:
+wait-on@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-4.0.1.tgz#c49ca18b1ea60580404feed9df76ab3af2425a56"
   integrity sha512-x83fmTH2X0KL7vXoGt9aV5x4SMCvO8A/NbwWpaYYh4NJ16d3KSgbHwBy9dVdHj0B30cEhOFRvDob4fnpUmZxvA==


### PR DESCRIPTION
This PR will add the `OrganisationUnitTree` component.
It offers the same basic behavior as the existing `OrgUnitTree` which can be found in `d2-ui@30`.

## d2-ui API that's supported by this component:

* `root` (now `roots`)
* `selected`
* `initiallyExpanded`
* `onExpand`
* `onCollapse`
* `onSelectClick` (now `onChange`)
* `onChildrenLoaded`
* `orgUnitsPathsToInclude` (now `filter`)
* `forceReloadChildren` (now `forceReload`)
* `highlightSearchResults` (now `highlighted`)

## d2-ui API that is not covered yet

* `idsThatShouldBeReloaded`
  There's a comment in the propTypes why we can't do this yet
* `onChangeCurrentRoot`
  Root can't be replaced in the current version

## d2-ui API that's depricated

* `searchResults` (This is a duplicate of "orgUnitsPathsToInclude" (now `filter`))
* `displayNameProperty`
* `currentRoot`
* `labelStyle`
* `treeStyle`
* `selectedLabelStyle`
* `arrowSymbol`
* `hideCheckboxes`
* showFolderIcon
* disableSpacer
* checkboxColor