### PR TITLE
fix: don't break the layout when a data request fails

### DIFF
--- a/src/HeaderBar/index.js
+++ b/src/HeaderBar/index.js
@@ -34,9 +34,7 @@ export const HeaderBar = ({ appName, className }) => {
         },
     })
 
-    if (error) return <span>{`ERROR: ${error.message}`}</span>
-
-    if (!loading) {
+    if (!loading && !error) {
         // TODO: This will run every render which is probably wrong!  Also, setting the global locale shouldn't be done in the headerbar
         const locale = data.user.settings.keyUiLocale || 'en'
         i18n.changeLanguage(locale)
@@ -46,7 +44,7 @@ export const HeaderBar = ({ appName, className }) => {
         <header className={className}>
             <Logo />
 
-            {!loading && (
+            {!loading && !error && (
                 <>
                     <Title
                         app={appName}

--- a/stories/HeaderBar.stories.js
+++ b/stories/HeaderBar.stories.js
@@ -85,3 +85,8 @@ storiesOf('HeaderBar', module)
             <HeaderBar appName="Example!" />
         </CustomDataProvider>
     ))
+    .add('Error!', () => (
+        <CustomDataProvider data={{}}>
+            <HeaderBar appName="Example!" />
+        </CustomDataProvider>
+    ))


### PR DESCRIPTION
Similar to #7, but for errors - as a rule we shouldn't break component layout flow when waiting for data or indicating failed requests.  I think generally we should just omit unloaded data unless there's a good UX alternative (tasteful spinners, red error border, etc)