### PR TITLE
 chore: don't pin peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "typeface-roboto": "^0.0.54"
     },
     "peerDependencies": {
-        "@dhis2/app-runtime": "1.1.0",
+        "@dhis2/app-runtime": "^1.1.0",
         "prop-types": "^15",
         "react": "^16.8",
         "react-dom": "^16.8"


### PR DESCRIPTION
I don't think we want to pin peerDeps to a specific version... I assume the reason for this was to ensure that green-keeper would catch minor and patch updates?