### PR TITLE
fix(headerbar): Broken link to apps resource

### DIFF
--- a/src/HeaderBar/index.js
+++ b/src/HeaderBar/index.js
@@ -27,7 +27,7 @@ export const HeaderBar = ({ appName, className }) => {
             resource: 'me',
         },
         apps: {
-            resource: '../dhis-web-commons/menu/getModules.action',
+            resource: '../../dhis-web-commons/menu/getModules.action',
         },
         notifications: {
             resource: 'me/dashboard',


### PR DESCRIPTION
### 🔢 Implementation

Since we are accessing ```baseUrl/api/version/resource``` we need to go back two levels instead of only one.

Right now it leads to a 404 when trying to access this resource since it's fetching ```/api/dhis-web-commons/menu/getModules.action```.

### 📔 Additional notes

With ```apiVersion=""``` the two-level nesting seems to work fine too, even though the header bar still not supports it (https://github.com/dhis2/app-runtime/issues/15).

![image](https://user-images.githubusercontent.com/2181866/60867030-25eb1400-a22a-11e9-8cc1-d3437df16856.png)
