### PR TITLE
fix: use action:: prefix for action resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "typeface-roboto": "^0.0.54"
     },
     "peerDependencies": {
-        "@dhis2/app-runtime": "^1.1.0",
+        "@dhis2/app-runtime": "^1.3.0",
         "prop-types": "^15",
         "react": "^16.8",
         "react-dom": "^16.8"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@babel/plugin-transform-react-constant-elements": "^7.5.0",
         "@babel/preset-env": "^7.5.2",
         "@babel/preset-react": "^7.0.0",
-        "@dhis2/app-runtime": "1.2.0",
+        "@dhis2/app-runtime": "1.3.0",
         "@dhis2/cli-style": "3.3.4",
         "@dhis2/d2-i18n-extract": "1.0.8",
         "@dhis2/d2-i18n-generate": "1.1.1",

--- a/src/HeaderBar/index.js
+++ b/src/HeaderBar/index.js
@@ -27,7 +27,7 @@ export const HeaderBar = ({ appName, className }) => {
             resource: 'me',
         },
         apps: {
-            resource: '../dhis-web-commons/menu/getModules.action',
+            resource: 'action::menu/getModules',
         },
         notifications: {
             resource: 'me/dashboard',

--- a/stories/HeaderBar.stories.js
+++ b/stories/HeaderBar.stories.js
@@ -15,7 +15,7 @@ const customData = {
             keyUiLocale: 'en',
         },
     },
-    '../../dhis-web-commons/menu/getModules.action': {
+    'action::menu/getModules': {
         modules: [
             {
                 name: 'dhis-web-dashboard',

--- a/yarn.lock
+++ b/yarn.lock
@@ -369,7 +369,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
 
-"@babel/plugin-proposal-object-rest-spread@^7.3.2", "@babel/plugin-proposal-object-rest-spread@^7.4.3", "@babel/plugin-proposal-object-rest-spread@^7.5.0", "@babel/plugin-proposal-object-rest-spread@^7.5.2":
+"@babel/plugin-proposal-object-rest-spread@^7.3.2", "@babel/plugin-proposal-object-rest-spread@^7.4.3", "@babel/plugin-proposal-object-rest-spread@^7.5.2":
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.2.tgz#ec92b0c6419074ea7af77c78b7c5d42041f2f5a9"
   integrity sha512-C/JU3YOx5J4d9s0GGlJlYXVwsbd5JmqQ0AvB7cIDAx7nN57aDTnlJEsZJPuSskeBtMGFWSWU5Q+piTiDe0s7FQ==
@@ -1117,10 +1117,10 @@
   dependencies:
     find-up "^2.1.0"
 
-"@dhis2/app-runtime@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-1.2.0.tgz#87e22d817a13d45a7d89d854e6152cfd959ec55d"
-  integrity sha512-2JOKPYIdNVpb6vVwuqmO+1ERelUdOYqFgWJDD2xnMNWYhNOPxvqi8v5rPLaOfTsUWeQ0RgBukPfRRJbBSqkipw==
+"@dhis2/app-runtime@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-1.3.0.tgz#7f2e37ceb8b4df8642b18128aaa153b852400ba1"
+  integrity sha512-QF/B4aJpPmDk/roNrRg/nETJ07BcuD1uV/lVGa4BnnvYwOz1P+PxSYA/qdTXzgpcUK1rc6nMsuORGTCVNvWrVQ==
 
 "@dhis2/cli-helpers-engine@1.3.0":
   version "1.3.0"


### PR DESCRIPTION
I believe this supercedes #53

It looks like we're going to want to change the server's response to `getModules` since it includes entries like this `../icons/dhis-web-maps.png`.  What's the timeline for moving away from an `actions` endpoint and to a true `api` endpoint?  Hopefully we could normalize the responses better when making that transition.