### PR TITLE
chore: remove deploy-build to d2-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,6 @@ deploy:
 - provider: script
   skip_cleanup: true
   script:
-  - npx --package @dhis2/deploy-build deploy-build
-  on:
-    tags: false
-    branch: master
-- provider: script
-  skip_cleanup: true
-  script:
   - npx @dhis2/cli-utils release --publish npm
   on:
     tags: false


### PR DESCRIPTION
We are moving the docs to Netlify: https://widgets.ui.dhis2.nu/