### PR TITLE
refactor: move HeaderBar and Profile up one level

### DIFF
--- a/src/HeaderBar.js
+++ b/src/HeaderBar.js
@@ -3,19 +3,19 @@ import PropTypes from 'prop-types'
 
 import { colors } from '@dhis2/ui-core'
 
-import Apps from './Apps'
-import Profile from './Profile'
+import Apps from './HeaderBar/Apps.js'
+import Profile from './HeaderBar/Profile.js'
 
 import css from 'styled-jsx/css'
 
 import { useDataQuery } from '@dhis2/app-runtime'
 
-import { Logo } from './Logo.js'
-import { Title } from './Title.js'
+import { Logo } from './HeaderBar/Logo.js'
+import { Title } from './HeaderBar/Title.js'
 
-import { Notifications } from './Notifications.js'
+import { Notifications } from './HeaderBar/Notifications.js'
 
-import '../locales'
+import './locales'
 import i18n from '@dhis2/d2-i18n'
 
 const query = {

--- a/src/HeaderBar/Logo.js
+++ b/src/HeaderBar/Logo.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import css from 'styled-jsx/css'
 
-import { LogoImage } from './LogoImage'
+import { LogoImage } from './LogoImage.js'
 
 export const Logo = ({ baseUrl }) => (
     <div data-test-id="headerbar-logo">

--- a/src/HeaderBar/Notifications.js
+++ b/src/HeaderBar/Notifications.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { NotificationIcon } from './NotificationIcon'
+import { NotificationIcon } from './NotificationIcon.js'
 
 export const Notifications = ({ interpretations, messages, contextPath }) => (
     <div data-test-id="headerbar-notifications">

--- a/src/HeaderBar/Profile.js
+++ b/src/HeaderBar/Profile.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types'
 
 import css from 'styled-jsx/css'
 
-import { ProfileMenu } from './ProfileMenu.js'
+import { ProfileMenu } from './Profile/ProfileMenu.js'
 
-import { TextIcon } from '../TextIcon.js'
-import { ImageIcon } from '../ImageIcon.js'
+import { TextIcon } from './TextIcon.js'
+import { ImageIcon } from './ImageIcon.js'
 
 function avatarPath(avatar, contextPath) {
     if (!avatar) {


### PR DESCRIPTION
I've moved up the HeaderBar and Profile component to match the architecture that we've implemented in `ui-core`.

I've also added the missing `.js` extension to import statement paths.