### PR TITLE
fix(headerbar): Proptypes for notifications

### DIFF
--- a/src/HeaderBar/Notifications.js
+++ b/src/HeaderBar/Notifications.js
@@ -32,6 +32,6 @@ export const Notifications = ({ interpretations, messages, contextPath }) => (
 )
 Notifications.propTypes = {
     contextPath: propTypes.string,
-    interpretations: propTypes.string,
-    messages: propTypes.string,
+    interpretations: propTypes.number,
+    messages: propTypes.number,
 }


### PR DESCRIPTION
Endpoint ``/api/me/dashboard`` returns the following:

```
{
"unreadInterpretations": 0,
"unreadMessageConversations": 0
}
```

However the prop-types in the Notifications component has ``string`` instead of ``number``.

This is causing two warnings in the application side:

![image](https://user-images.githubusercontent.com/2181866/70416910-614f7000-1a60-11ea-8d93-be5022c36d5b.png)
