### PR TITLE
docs: rich text parser feature files

### DIFF
--- a/cypress/integration/RichTextParser/Emoticons.feature
+++ b/cypress/integration/RichTextParser/Emoticons.feature
@@ -1,0 +1,15 @@
+Feature: Emoticon parsing
+
+  Scenario Outline: Emoticons strings
+      Given there is a text string of <string>
+      And the string is not preceded immediately by a non-space character
+      Then the parsed text string will be rendered as <result>
+
+      Examples:
+          | string | result                 |
+          | :)     | <span>\u{1F642}</span> |
+          | :-)    | <span>\u{1F642}</span> |
+          | :(     | <span>\u{2639}</span>  |
+          | :-(    | <span>\u{2639}</span>  |
+          | :+1    | <span>\u{1F44D}</span> |
+          | :-1    | <span>\u{1F44E}</span> |

--- a/cypress/integration/RichTextParser/Headers.feature
+++ b/cypress/integration/RichTextParser/Headers.feature
@@ -1,0 +1,17 @@
+Feature: Header items parsing
+
+  Scenario Outline: Headers
+    Given there is a text string of <string>
+    Then the parsed text will be rendered as <result>
+
+    Examples:
+      | string        | result             |
+      | # sky         | <h1>sky</h1>       |
+      | ## sky        | <h2>sky</h2>       |
+      | ### sky       | <h3>sky</h3>       |
+      | #### sky      | <h4>sky</h4>       |
+      | ##### sky     | <h5>sky</h5>       |
+      | ###### sky    | <h6>sky</h6>       |
+      | the # sky     | the # sky          |
+      | #sky          | #sky               |
+      | ### the # sky | <h3>the # sky</h3> |

--- a/cypress/integration/RichTextParser/Lists.feature
+++ b/cypress/integration/RichTextParser/Lists.feature
@@ -1,0 +1,73 @@
+Feature: List item parsing
+
+  Scenario: Valid unordered list
+    Given a string with content
+      """
+      - one
+      - two
+      - three
+      """
+    Then the parsed text will be rendered as "<ul><li>one</li><li>two</li><li>three</li></ul>"
+
+  Scenario: Invalid unordered list
+    Given a string with content
+      """
+      -one
+      -two
+      -three
+      """
+    Then the parsed text will be rendered as "<p>-one -two -three</p>"
+
+  Scenario: Invalid list item inside unordered list
+    Given a string with content
+      """
+      - one
+      -two
+      - three
+      """
+    Then the parsed text will be rendered as "<ul><li>one -two</li><li>three</li></ul>"
+
+  Scenario: Valid ordered list
+    Given a string with content
+      """
+      1. one
+      2. two
+      3. three
+      """
+    Then the parsed text will be rendered as "<ol><li>one</li><li>two</li><li>three</li></ol>"
+
+  Scenario: Ordered list with offset start
+    Given a string with content
+      """
+      22. one
+      23. two
+      24. three
+      """
+    Then the parsed text will be rendered as "<ol start='22'><li>one</li><li>two</li><li>three</li></ol>"
+
+  Scenario: Invalid ordered list
+    Given a string with content
+      """
+      1.one
+      2.two
+      3.three
+      """
+    Then the parsed text will be rendered as "<p>1.one 2.two 3.three</p>"
+
+  Scenario: Invalid ordered list item inside ordered list
+    Given a string with content
+      """
+      1. one
+      2.two
+      3. three
+      """
+    Then the parsed text will be rendered as "<ol><li>one 2.two</li><li>three</li></ol>"
+
+  Scenario: Mixed list item types
+    Given a string with content
+      """
+      - one
+      2. two
+      - three
+      """
+    Then the parsed text will be rendered as "<ul><li>one</li></ul><ol start='2'><li>two</li></ol><ul><li>three</li></ul>"

--- a/cypress/integration/RichTextParser/Lists.feature
+++ b/cypress/integration/RichTextParser/Lists.feature
@@ -1,7 +1,7 @@
 Feature: List item parsing
 
   Scenario: Valid unordered list
-    Given a string with content
+    Given there is a string with content
       """
       - one
       - two
@@ -10,7 +10,7 @@ Feature: List item parsing
     Then the parsed text will be rendered as "<ul><li>one</li><li>two</li><li>three</li></ul>"
 
   Scenario: Invalid unordered list
-    Given a string with content
+    Given there is a string with content
       """
       -one
       -two
@@ -19,7 +19,7 @@ Feature: List item parsing
     Then the parsed text will be rendered as "<p>-one -two -three</p>"
 
   Scenario: Invalid list item inside unordered list
-    Given a string with content
+    Given there is a string with content
       """
       - one
       -two
@@ -28,7 +28,7 @@ Feature: List item parsing
     Then the parsed text will be rendered as "<ul><li>one -two</li><li>three</li></ul>"
 
   Scenario: Valid ordered list
-    Given a string with content
+    Given there is a string with content
       """
       1. one
       2. two
@@ -37,7 +37,7 @@ Feature: List item parsing
     Then the parsed text will be rendered as "<ol><li>one</li><li>two</li><li>three</li></ol>"
 
   Scenario: Ordered list with offset start
-    Given a string with content
+    Given there is a string with content
       """
       22. one
       23. two
@@ -46,7 +46,7 @@ Feature: List item parsing
     Then the parsed text will be rendered as "<ol start='22'><li>one</li><li>two</li><li>three</li></ol>"
 
   Scenario: Invalid ordered list
-    Given a string with content
+    Given there is a string with content
       """
       1.one
       2.two
@@ -55,7 +55,7 @@ Feature: List item parsing
     Then the parsed text will be rendered as "<p>1.one 2.two 3.three</p>"
 
   Scenario: Invalid ordered list item inside ordered list
-    Given a string with content
+    Given there is a string with content
       """
       1. one
       2.two
@@ -64,7 +64,7 @@ Feature: List item parsing
     Then the parsed text will be rendered as "<ol><li>one 2.two</li><li>three</li></ol>"
 
   Scenario: Mixed list item types
-    Given a string with content
+    Given there is a string with content
       """
       - one
       2. two

--- a/cypress/integration/RichTextParser/Text_Style.feature
+++ b/cypress/integration/RichTextParser/Text_Style.feature
@@ -1,0 +1,20 @@
+Feature: Text style parsing
+
+  Scenario Outline: String wrapped by tags
+      Given there is a text string preceded by <string>
+      Then the parsed text will be rendered as <result>
+
+      Examples:
+          | string       | result                                 |
+          | *sky*        | <strong>sky</strong>                   |
+          | _sky_        | <em>sky</em>                           |
+          | *_sky_*      | <strong><em>sky</em></strong>          |
+          | *_sky*_      | *<em>sky*</em>                         |
+          | * sky *      | * sky *                                |
+          | **sky**      | <strong><strong>sky</strong></strong>  |
+          | _sky*        | _sky*                                  |
+          | _*sky*_      | <em><strong>sky</strong></em>          |
+          | _*_sky_*_    | <em><strong><em>sky</em></strong></em> |
+          | *the sky*    | <strong>the sky</strong>               |
+          | _the *sky*_  | <em>the <strong>sky</strong></em>      |
+          | *_the* _sky* | <strong><em>the</strong> </em>sky*     |

--- a/cypress/integration/RichTextParser/URL_Detection.feature
+++ b/cypress/integration/RichTextParser/URL_Detection.feature
@@ -1,0 +1,19 @@
+Feature: Automatic url detection
+
+  Scenario Outline: Automatic URL detection
+      Given there is a text string that contains the URL of <URL>
+      And the URL is not preceded or followed immediately by a non-space character
+      Then the rendered URL is a <result>
+
+      Examples:
+        | URL                                        | result                                                                                              |
+        | duck.com                                   | <a href="http://duck.com">duck.com</a>                                                              |
+        | www.duck.com                               | <a href="http://www.duck.com">www.duck.com</a>                                                      |
+        | https://www.eff.org/                       | <a href="https://www.eff.org/">https://www.eff.org/</a>                                             |
+        | https://www.eff.org/about                  | <a href="https://www.eff.org/about">https://www.eff.org/about</a>                                   |
+        | act.eff.org                                | <a href="http://act.eff.org">act.eff.org</a>                                                        |
+        | https://www.eff.org/events/list?type=event | <a href="https://www.eff.org/events/list?type=event">https://www.eff.org/events/list?type=event</a> |
+        | ef*f*.org                                  | <a href="http://ef*f*.org">ef*f*.org</a>                                                            |
+        | e_f_f.org                                  | <a href="http://e_f_f.org">e_f_f.org</a>                                                            |
+        | example.com/path_to                        | <a href="http://example.com/path_to">example.com/path_to</a>                                        |
+        | notion.so                                  | <a href="http://notion.so">notion.so</a>                                                            |

--- a/cypress/integration/RichTextParser/URL_Detection.feature
+++ b/cypress/integration/RichTextParser/URL_Detection.feature
@@ -6,14 +6,14 @@ Feature: Automatic url detection
       Then the rendered URL is a <result>
 
       Examples:
-        | URL                                        | result                                                                                              |
-        | duck.com                                   | <a href="http://duck.com">duck.com</a>                                                              |
-        | www.duck.com                               | <a href="http://www.duck.com">www.duck.com</a>                                                      |
-        | https://www.eff.org/                       | <a href="https://www.eff.org/">https://www.eff.org/</a>                                             |
-        | https://www.eff.org/about                  | <a href="https://www.eff.org/about">https://www.eff.org/about</a>                                   |
-        | act.eff.org                                | <a href="http://act.eff.org">act.eff.org</a>                                                        |
-        | https://www.eff.org/events/list?type=event | <a href="https://www.eff.org/events/list?type=event">https://www.eff.org/events/list?type=event</a> |
-        | ef*f*.org                                  | <a href="http://ef*f*.org">ef*f*.org</a>                                                            |
-        | e_f_f.org                                  | <a href="http://e_f_f.org">e_f_f.org</a>                                                            |
-        | example.com/path_to                        | <a href="http://example.com/path_to">example.com/path_to</a>                                        |
-        | notion.so                                  | <a href="http://notion.so">notion.so</a>                                                            |
+        | URL                                        | result                                                                                                                                        |
+        | duck.com                                   | <a href="http://duck.com" target="_blank" rel="noopener noreferrer">duck.com</a>                                                              |
+        | www.duck.com                               | <a href="http://www.duck.com" target="_blank" rel="noopener noreferrer">www.duck.com</a>                                                      |
+        | https://www.eff.org/                       | <a href="https://www.eff.org/" target="_blank" rel="noopener noreferrer">https://www.eff.org/</a>                                             |
+        | https://www.eff.org/about                  | <a href="https://www.eff.org/about" target="_blank" rel="noopener noreferrer">https://www.eff.org/about</a>                                   |
+        | act.eff.org                                | <a href="http://act.eff.org" target="_blank" rel="noopener noreferrer">act.eff.org</a>                                                        |
+        | https://www.eff.org/events/list?type=event | <a href="https://www.eff.org/events/list?type=event" target="_blank" rel="noopener noreferrer">https://www.eff.org/events/list?type=event</a> |
+        | ef*f*.org                                  | <a href="http://ef*f*.org" target="_blank" rel="noopener noreferrer">ef*f*.org</a>                                                            |
+        | e_f_f.org                                  | <a href="http://e_f_f.org" target="_blank" rel="noopener noreferrer">e_f_f.org</a>                                                            |
+        | example.com/path_to                        | <a href="http://example.com/path_to" target="_blank" rel="noopener noreferrer">example.com/path_to</a>                                        |
+        | notion.so                                  | <a href="http://notion.so" target="_blank" rel="noopener noreferrer">notion.so</a>                                                            |


### PR DESCRIPTION
Feature files for the rich text parser. The features here could theoretically be included in ui-core, but planned features such as @mentions will include DHIS2 logic, making this a ui-widgets component.

For reference, the feature files are based on a custom implementation of [markdown-it](https://github.com/markdown-it/markdown-it).

@varl I noticed you already included some tests/specs in the d2ui rich text port [here](https://github.com/dhis2/ui-widgets/blob/port-rich-text/src/RichText/parser/__tests__/MdParser.spec.js). Many of the feature files I have written replicate these specs, so I think everything is covered. I'll leave it up to you whether to include both sets of features/specs.