### PR TITLE
feat: introduce translated selects and file-input-field-with-list

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,23 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-05-06T10:04:38.118Z\n"
-"PO-Revision-Date: 2019-05-06T10:04:38.118Z\n"
+"POT-Creation-Date: 2020-02-11T10:59:00.005Z\n"
+"PO-Revision-Date: 2020-02-11T10:59:00.005Z\n"
+
+msgid "No files selected yet"
+msgstr ""
+
+msgid "No file selected yet"
+msgstr ""
+
+msgid "Upload files"
+msgstr ""
+
+msgid "Upload file"
+msgstr ""
+
+msgid "Remove"
+msgstr ""
 
 msgid "Search apps"
 msgstr ""
@@ -27,4 +42,16 @@ msgid "About DHIS2"
 msgstr ""
 
 msgid "Logout"
+msgstr ""
+
+msgid "Clear"
+msgstr ""
+
+msgid "Filter"
+msgstr ""
+
+msgid "Loading"
+msgstr ""
+
+msgid "No Match"
 msgstr ""

--- a/src/FileInputFieldWithList.js
+++ b/src/FileInputFieldWithList.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+import { FileInputFieldWithList as UiCoreFileInputFieldWithList } from '@dhis2/ui-core'
+
+/**
+ * @module
+ *
+ * @param {FileInputFieldWithList.PropTypes} props
+ * @returns {React.Component}
+ *
+ * @example import { FileInputFieldWithList } from '@dhis2/ui-widgets'
+ */
+
+const placeholderText = (placeholder, multiple) =>
+    placeholder || multiple
+        ? i18n.t('No files selected yet')
+        : i18n.t('No file selected yet')
+
+const buttonLabelText = (label, multiple) =>
+    label || multiple ? i18n.t('Upload files') : i18n.t('Upload file')
+
+const FileInputFieldWithList = ({
+    multiple,
+    buttonLabel,
+    placeholder,
+    ...rest
+}) => (
+    <UiCoreFileInputFieldWithList
+        multiple={multiple}
+        buttonLabel={buttonLabelText(buttonLabel, multiple)}
+        placeHolder={placeholderText(placeholder, multiple)}
+        {...rest}
+    />
+)
+
+/**
+ * @typedef {Object} PropTypes
+ * @description This component adds translations to its counterpart in ui-core.
+ * The default property values for locale "en" are listed below.
+ * For more information, please refer to ui-core:
+ * <ul>
+ * <li>{@link https://ui-core.dhis2.nu/#module_FileInputFieldWithList|API docs}</li>
+ * <li>{@link https://ui-core.dhis2.nu/demo/?path=/story/fileinputfieldwithlist--default|Stories}</li>
+ * </ul>
+ * @static
+ *
+ * @prop {string} [dataTest=dhis2-uiwidgets-fileinputfieldwithlist]
+ * @prop {string} [removeText=Remove]
+ * @prop {string} [buttonLabel=Upload file] Will switch to "Upload file<b>s</b>" if multiple is true
+ * @prop {string} [placeholder=No file selected yet] Will switch to "No file<b>s</b> selected yet" if multiple is true
+ */
+
+FileInputFieldWithList.defaultProps = {
+    dataTest: 'dhis2-uiwidgets-fileinputfieldwithlist',
+    removeText: i18n.t('Remove'),
+}
+FileInputFieldWithList.propTypes = UiCoreFileInputFieldWithList.propTypes
+FileInputFieldWithList.displayName = 'FileInputFieldWithListTranslated'
+
+export { FileInputFieldWithList }

--- a/src/FileInputFieldWithList.js
+++ b/src/FileInputFieldWithList.js
@@ -9,6 +9,11 @@ import { FileInputFieldWithList as UiCoreFileInputFieldWithList } from '@dhis2/u
  * @returns {React.Component}
  *
  * @example import { FileInputFieldWithList } from '@dhis2/ui-widgets'
+ * @description This component adds translations to its counterpart in ui-core.
+ * The default property values for locale "en" are listed below.
+ * For more information, please refer to ui-core:
+ * @see Demo: {@link https://ui-core.dhis2.nu/#module_FileInputFieldWithList}
+ * @see API docs: {@link https://ui-core.dhis2.nu/demo/?path=/story/fileinputfieldwithlist--default}
  */
 
 const placeholderText = (placeholder, multiple) =>
@@ -35,13 +40,6 @@ const FileInputFieldWithList = ({
 
 /**
  * @typedef {Object} PropTypes
- * @description This component adds translations to its counterpart in ui-core.
- * The default property values for locale "en" are listed below.
- * For more information, please refer to ui-core:
- * <ul>
- * <li>{@link https://ui-core.dhis2.nu/#module_FileInputFieldWithList|API docs}</li>
- * <li>{@link https://ui-core.dhis2.nu/demo/?path=/story/fileinputfieldwithlist--default|Stories}</li>
- * </ul>
  * @static
  *
  * @prop {string} [dataTest=dhis2-uiwidgets-fileinputfieldwithlist]

--- a/src/FileInputFieldWithList.js
+++ b/src/FileInputFieldWithList.js
@@ -18,11 +18,11 @@ import { FileInputFieldWithList as UiCoreFileInputFieldWithList } from '@dhis2/u
 
 const placeholderText = (placeholder, multiple) =>
     placeholder || multiple
-        ? i18n.t('No files selected yet')
-        : i18n.t('No file selected yet')
+        ? i18n.t('No files selected')
+        : i18n.t('No file selected')
 
 const buttonLabelText = (label, multiple) =>
-    label || multiple ? i18n.t('Upload files') : i18n.t('Upload file')
+    label || multiple ? i18n.t('Upload files') : i18n.t('Upload a file')
 
 const FileInputFieldWithList = ({
     multiple,

--- a/src/MultiSelectField.js
+++ b/src/MultiSelectField.js
@@ -23,7 +23,7 @@ MultiSelectField.defaultProps = {
     clearText: i18n.t('Clear'),
     filterPlaceholder: i18n.t('Filter'),
     loadingText: i18n.t('Loading'),
-    noMatchText: i18n.t('No Match'),
+    noMatchText: i18n.t('No match found'),
 }
 /**
  * @typedef {Object} PropTypes

--- a/src/MultiSelectField.js
+++ b/src/MultiSelectField.js
@@ -9,6 +9,11 @@ import { MultiSelectField as UiCoreMultiSelectField } from '@dhis2/ui-core'
  * @returns {React.Component}
  *
  * @example import { MultiSelectField } from '@dhis2/ui-widgets'
+ * @description This component adds translations to its counterpart in ui-core.
+ * The default property values for locale "en" are listed below.
+ * For more information, please refer to ui-core:
+ * @see Demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/multiselectfield--default}
+ * @see API docs: {@link https://ui-core.dhis2.nu/#module_MultiSelectField}
  */
 
 const MultiSelectField = props => <UiCoreMultiSelectField {...props} />
@@ -22,13 +27,6 @@ MultiSelectField.defaultProps = {
 }
 /**
  * @typedef {Object} PropTypes
- * @description This component adds translations to its counterpart in ui-core.
- * The default property values for locale "en" are listed below.
- * For more information, please refer to ui-core:
- * <ul>
- * <li>{@link https://ui-core.dhis2.nu/#module_MultiSelectField|API docs}</li>
- * <li>{@link https://ui-core.dhis2.nu/demo/?path=/story/multiselectfield--default|Stories}</li>
- * </ul>
  * @static
  *
  * @prop {string} [dataTest=dhis2-uiwidgets-multiselectfield]

--- a/src/MultiSelectField.js
+++ b/src/MultiSelectField.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+import { MultiSelectField as UiCoreMultiSelectField } from '@dhis2/ui-core'
+
+/**
+ * @module
+ *
+ * @param {MultiSelectField.PropTypes} props
+ * @returns {React.Component}
+ *
+ * @example import { MultiSelectField } from '@dhis2/ui-widgets'
+ */
+
+const MultiSelectField = props => <UiCoreMultiSelectField {...props} />
+
+MultiSelectField.defaultProps = {
+    dataTest: 'dhis2-uiwidgets-multiselectfield',
+    clearText: i18n.t('Clear'),
+    filterPlaceholder: i18n.t('Filter'),
+    loadingText: i18n.t('Loading'),
+    noMatchText: i18n.t('No Match'),
+}
+/**
+ * @typedef {Object} PropTypes
+ * @description This component adds translations to its counterpart in ui-core.
+ * The default property values for locale "en" are listed below.
+ * For more information, please refer to ui-core:
+ * <ul>
+ * <li>{@link https://ui-core.dhis2.nu/#module_MultiSelectField|API docs}</li>
+ * <li>{@link https://ui-core.dhis2.nu/demo/?path=/story/multiselectfield--default|Stories}</li>
+ * </ul>
+ * @static
+ *
+ * @prop {string} [dataTest=dhis2-uiwidgets-multiselectfield]
+ * @prop {string} [clearText=Clear] - Only required if clearable is true
+ * @prop {string} [filterPlaceholder=Filter]
+ * @prop {string} [loadingText=Loading]
+ * @prop {string} [noMatchText=No Match] - Only required if filterable is true
+ */
+
+MultiSelectField.propTypes = UiCoreMultiSelectField.propTypes
+MultiSelectField.displayName = 'MultiSelectFieldTranslated'
+
+export { MultiSelectField }

--- a/src/SingleSelectField.js
+++ b/src/SingleSelectField.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+import { SingleSelectField as UiCoreSingleSelectField } from '@dhis2/ui-core'
+
+/**
+ * @module
+ *
+ * @param {SingleSelectField.PropTypes} props
+ * @returns {React.Component}
+ *
+ * @example import { SingleSelectField } from '@dhis2/ui-widgets'
+ */
+
+const SingleSelectField = props => <UiCoreSingleSelectField {...props} />
+
+SingleSelectField.defaultProps = {
+    dataTest: 'dhis2-uiwidgets-SingleSelectField',
+    clearText: i18n.t('Clear'),
+    filterPlaceholder: i18n.t('Filter'),
+    loadingText: i18n.t('Loading'),
+    noMatchText: i18n.t('No Match'),
+}
+/**
+ * @typedef {Object} PropTypes
+ * @description This component adds translations to its counterpart in ui-core.
+ * The default property values for locale "en" are listed below.
+ * For more information, please refer to ui-core:
+ * <ul>
+ * <li>{@link https://ui-core.dhis2.nu/#module_SingleSelectField|API docs}</li>
+ * <li>{@link https://ui-core.dhis2.nu/demo/?path=/story/singleselectfield--default|Stories}</li>
+ * </ul>
+ * @static
+ *
+ * @prop {string} [dataTest]
+ * @prop {string} [clearText=Clear] - Only required if clearable is true
+ * @prop {string} [filterPlaceholder=Filter]
+ * @prop {string} [loadingText=Loading]
+ * @prop {string} [noMatchText=No Match] - Only required if filterable is true
+ */
+
+SingleSelectField.propTypes = UiCoreSingleSelectField.propTypes
+SingleSelectField.displayName = 'SingleSelectFieldTranslated'
+
+export { SingleSelectField }

--- a/src/SingleSelectField.js
+++ b/src/SingleSelectField.js
@@ -23,7 +23,7 @@ SingleSelectField.defaultProps = {
     clearText: i18n.t('Clear'),
     filterPlaceholder: i18n.t('Filter'),
     loadingText: i18n.t('Loading'),
-    noMatchText: i18n.t('No Match'),
+    noMatchText: i18n.t('No match found'),
 }
 /**
  * @typedef {Object} PropTypes

--- a/src/SingleSelectField.js
+++ b/src/SingleSelectField.js
@@ -9,6 +9,11 @@ import { SingleSelectField as UiCoreSingleSelectField } from '@dhis2/ui-core'
  * @returns {React.Component}
  *
  * @example import { SingleSelectField } from '@dhis2/ui-widgets'
+ * @description This component adds translations to its counterpart in ui-core.
+ * The default property values for locale "en" are listed below.
+ * For more information, please refer to ui-core:
+ * @see Demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/singleselectfield--default}
+ * @see API docs: {@link https://ui-core.dhis2.nu/#module_SingleSelectField}
  */
 
 const SingleSelectField = props => <UiCoreSingleSelectField {...props} />
@@ -22,13 +27,6 @@ SingleSelectField.defaultProps = {
 }
 /**
  * @typedef {Object} PropTypes
- * @description This component adds translations to its counterpart in ui-core.
- * The default property values for locale "en" are listed below.
- * For more information, please refer to ui-core:
- * <ul>
- * <li>{@link https://ui-core.dhis2.nu/#module_SingleSelectField|API docs}</li>
- * <li>{@link https://ui-core.dhis2.nu/demo/?path=/story/singleselectfield--default|Stories}</li>
- * </ul>
  * @static
  *
  * @prop {string} [dataTest]

--- a/src/__demo__/FileInputFieldWithList.stories.future.js
+++ b/src/__demo__/FileInputFieldWithList.stories.future.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import { FileInputFieldWithList } from '../index.js'
+
+const files = [new File([], 'test1.txt')]
+
+storiesOf('FileInputFieldWithList', module)
+    .add('Single', () => <FileInputFieldWithList files={files} />)
+    .add('Multiple', () => <FileInputFieldWithList multiple files={files} />)

--- a/src/__demo__/MultiSelectField.stories.js
+++ b/src/__demo__/MultiSelectField.stories.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { MultiSelectOption } from '@dhis2/ui-core'
+
+import { MultiSelectField } from '../index.js'
+
+const selected = [
+    { value: '1', label: 'one' },
+    { value: '2', label: 'two' },
+]
+
+storiesOf('MultiSelectField', module).add('Default', () => (
+    <MultiSelectField
+        label="Open the select to see the default filterPlaceholder text and loadingText"
+        helpText="Type 'xx' into the filter input to see the default noMatchText"
+        selected={selected}
+        filterable
+        clearable
+        loading
+    >
+        <MultiSelectOption key="1" value="1" label="one" />
+        <MultiSelectOption key="2" value="2" label="two" />
+        <MultiSelectOption key="3" value="3" label="three" />
+        <MultiSelectOption key="4" value="4" label="four" />
+        <MultiSelectOption key="5" value="5" label="five" />
+    </MultiSelectField>
+))

--- a/src/__demo__/SingleSelect.stories.js
+++ b/src/__demo__/SingleSelect.stories.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { SingleSelectOption } from '@dhis2/ui-core'
+
+import { SingleSelectField } from '../index.js'
+
+const selected = [
+    { value: '1', label: 'one' },
+    { value: '2', label: 'two' },
+]
+
+storiesOf('SingleSelectField', module).add('Default', () => (
+    <SingleSelectField
+        label="Open the select to see the default filterPlaceholder text and loadingText"
+        helpText="Type 'xx' into the filter input to see the default noMatchText"
+        selected={selected}
+        filterable
+        clearable
+        loading
+    >
+        <SingleSelectOption key="1" value="1" label="one" />
+        <SingleSelectOption key="2" value="2" label="two" />
+        <SingleSelectOption key="3" value="3" label="three" />
+        <SingleSelectOption key="4" value="4" label="four" />
+        <SingleSelectOption key="5" value="5" label="five" />
+    </SingleSelectField>
+))

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,4 @@
-export { HeaderBar } from './HeaderBar'
+export { FileInputFieldWithList } from './FileInputFieldWithList.js'
+export { HeaderBar } from './HeaderBar.js'
+export { MultiSelectField } from './MultiSelectField.js'
+export { SingleSelectField } from './SingleSelectField.js'

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export { FileInputFieldWithList } from './FileInputFieldWithList.js'
+// export { FileInputFieldWithList } from './FileInputFieldWithList.js'
 export { HeaderBar } from './HeaderBar.js'
 export { MultiSelectField } from './MultiSelectField.js'
 export { SingleSelectField } from './SingleSelectField.js'


### PR DESCRIPTION
Currently this one is still in draft, because it requires https://github.com/dhis2/ui-core/pull/787 to be merged in first, and then an updated version of `ui-core` here in `ui-widgets`.

This PR is quite opinionated, but has been discussed with @ismay and @Mohammer5 already when we were in Oslo. So, I think it is important that @varl has a look and considers the following points:
- We decided to only add documentation about the defaultProps that these components add and just refer back to ui-core for the rest.
- The way we've implemented this, it will not render anything to the DOM, but in React DevTools we will see an additional component. And bearing in mind that `ui-forms` will again add an additional component to the mix, we decided to use a displayName, so in DevTools it will be fairly obvious how the nesting works.

Also, I've opted for just including demo stories only. No e2e test and stories because these components don't have any internal logic.

One more point, a bit off topic... To deal with pluralisation, the `FileInputFieldWithList` doesn't use `defaultProps` but a helper function to get the correct strings. This works fine, but would make auto-documentation based on propTypes problematic. In this case we could even switch to using defaultProps and a fixed string (i.e. `No files(s) selected yet`), but this could possibly be a problem when re-implementing the way our docs are being generated. (see [this slack discussion](https://dhis2.slack.com/archives/CBM8LNEQM/p1581411245008400)) 