### PR TITLE
ci: respect skip ci directive in GitHub Actions workflows

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,6 +13,7 @@ jobs:
     cypress-run:
         name: E2E Tests
         runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         strategy:
             matrix:
                 containers: [1, 2, 3]

--- a/.github/workflows/node-lint.yml
+++ b/.github/workflows/node-lint.yml
@@ -10,6 +10,7 @@ jobs:
     pr:
         name: Lint
         runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v1
             - uses: actions/setup-node@v1

--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -9,6 +9,7 @@ jobs:
     process:
         name: Publish
         runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v1
             - uses: actions/setup-node@v1


### PR DESCRIPTION
Semantic release pushes `[skip ci]` commits which shouldn't be published again

We could be more fine-grained in our skip logic, say always running Cypress and Lint but not Publish, but for now this skips everything `ci`-like when `[skip ci]` is present, which mimics the previous behavior of Travis CI.