### PR TITLE
docs: correct demo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![DHIS2](https://github.com/dhis2/ui-widgets/workflows/DHIS2/badge.svg)[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 **[Online docs and demos (latest master
-build)](https://d2-ci.github.io/ui-widgets/)**
+build)](https://ui-widgets.dhis2.nu)**
 
 ## Testing
 


### PR DESCRIPTION
The link was pointing to the github pages deploy from `d2-ci`, which is incorrect and out of date