### PR TITLE
fix(headerbar): escape regex special chars in search

### DIFF
--- a/cypress/fixtures/HeaderBar/getModules.json
+++ b/cypress/fixtures/HeaderBar/getModules.json
@@ -57,14 +57,6 @@
             "description": ""
         },
         {
-            "name": "dhis-web-importexport",
-            "namespace": "/dhis-web-importexport",
-            "defaultAction": "../dhis-web-importexport/index.action",
-            "displayName": "Import/Export",
-            "icon": "../icons/dhis-web-importexport.png",
-            "description": ""
-        },
-        {
             "name": "WHO Metadata browser",
             "namespace": "WHO Metadata browser",
             "defaultAction": "https://play.dhis2.org/2.32.0/api/apps/WHO-Metadata-browser/index.html",

--- a/cypress/fixtures/HeaderBar/getModules.json
+++ b/cypress/fixtures/HeaderBar/getModules.json
@@ -59,17 +59,17 @@
         {
             "name": "WHO Metadata browser",
             "namespace": "WHO Metadata browser",
-            "defaultAction": "https://play.dhis2.org/2.32.0/api/apps/WHO-Metadata-browser/index.html",
+            "defaultAction": "https://debug.dhis2.org/dev/api/apps/WHO-Metadata-browser/index.html",
             "displayName": "",
-            "icon": "https://play.dhis2.org/2.32.0/api/apps/WHO-Metadata-browser/icons/medicine-48.png",
+            "icon": "https://debug.dhis2.org/dev/api/apps/WHO-Metadata-browser/icons/medicine-48.png",
             "description": ""
         },
         {
             "name": "Dashboard Classic",
             "namespace": "Dashboard Classic",
-            "defaultAction": "https://play.dhis2.org/2.32.0/api/apps/Dashboard-Classic/index.html",
+            "defaultAction": "https://debug.dhis2.org/dev/api/apps/Dashboard-Classic/index.html",
             "displayName": "",
-            "icon": "https://play.dhis2.org/2.32.0/api/apps/Dashboard-Classic/icon.png",
+            "icon": "https://debug.dhis2.org/dev/api/apps/Dashboard-Classic/icon.png",
             "description": "DHIS2 Legacy Dashboard App"
         }
     ]

--- a/cypress/fixtures/HeaderBar/getModulesWithSpecialChars.json
+++ b/cypress/fixtures/HeaderBar/getModulesWithSpecialChars.json
@@ -1,0 +1,229 @@
+{
+    "modules": [
+        {
+            "name": "/",
+            "namespace": "//",
+            "defaultAction": "..//.action",
+            "displayName": "A / character",
+            "icon": "../icons/dhis-web-dashboard.png",
+            "description": ""
+        },
+        {
+            "name": "-",
+            "namespace": "/-",
+            "defaultAction": "../-.action",
+            "displayName": "A - character",
+            "icon": "../icons/dhis-web-dashboard.png",
+            "description": ""
+        },
+        {
+            "name": "(",
+            "namespace": "/(",
+            "defaultAction": "../(.action",
+            "displayName": "A ( character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": ")",
+            "namespace": "/)",
+            "defaultAction": "../).action",
+            "displayName": "A ) character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "[",
+            "namespace": "/[",
+            "defaultAction": "../[.action",
+            "displayName": "A [ character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "]",
+            "namespace": "/]",
+            "defaultAction": "../].action",
+            "displayName": "A ] character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "{",
+            "namespace": "/{",
+            "defaultAction": "../{.action",
+            "displayName": "A { character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "}",
+            "namespace": "/}",
+            "defaultAction": "../}.action",
+            "displayName": "A } character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "*",
+            "namespace": "/*",
+            "defaultAction": "../*.action",
+            "displayName": "A * character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "+",
+            "namespace": "/+",
+            "defaultAction": "../+.action",
+            "displayName": "A + character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "?",
+            "namespace": "/?",
+            "defaultAction": "../?.action",
+            "displayName": "A ? character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": ".",
+            "namespace": "/.",
+            "defaultAction": "../..action",
+            "displayName": "A . character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": ",",
+            "namespace": "/,",
+            "defaultAction": "../,.action",
+            "displayName": "A , character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "^",
+            "namespace": "/^",
+            "defaultAction": "../^.action",
+            "displayName": "A ^ character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "$",
+            "namespace": "/$",
+            "defaultAction": "../$.action",
+            "displayName": "A $ character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "|",
+            "namespace": "/|",
+            "defaultAction": "../|.action",
+            "displayName": "A | character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "#",
+            "namespace": "/#",
+            "defaultAction": "../#.action",
+            "displayName": "A # character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "\\s",
+            "namespace": "/\\s",
+            "defaultAction": "../\\s.action",
+            "displayName": "A \\s character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+        {
+            "name": "\\",
+            "namespace": "/\\",
+            "defaultAction": "../\\.action",
+            "displayName": "A \\ character",
+            "icon": "../icons/dhis-web-data-visualizer.png",
+            "description": ""
+        },
+
+        {
+            "name": "dhis-web-dashboard",
+            "namespace": "/dhis-web-dashboard",
+            "defaultAction": "../dhis-web-dashboard/index.action",
+            "displayName": "Dashboard",
+            "icon": "../icons/dhis-web-dashboard.png",
+            "description": ""
+        },
+        {
+            "name": "dhis-web-capture",
+            "namespace": "/dhis-web-capture",
+            "defaultAction": "../dhis-web-capture/index.action",
+            "displayName": "Capture",
+            "icon": "../icons/dhis-web-capture.png",
+            "description": ""
+        },
+        {
+            "name": "dhis-web-maintenance",
+            "namespace": "/dhis-web-maintenance",
+            "defaultAction": "../dhis-web-maintenance/index.action",
+            "displayName": "Maintenance",
+            "icon": "../icons/dhis-web-maintenance.png",
+            "description": ""
+        },
+        {
+            "name": "dhis-web-maps",
+            "namespace": "/dhis-web-maps",
+            "defaultAction": "../dhis-web-maps/index.action",
+            "displayName": "Maps",
+            "icon": "../icons/dhis-web-maps.png",
+            "description": ""
+        },
+        {
+            "name": "dhis-web-event-reports",
+            "namespace": "/dhis-web-event-reports",
+            "defaultAction": "../dhis-web-event-reports/index.action",
+            "displayName": "Event Reports",
+            "icon": "../icons/dhis-web-event-reports.png",
+            "description": ""
+        },
+        {
+            "name": "dhis-web-interpretation",
+            "namespace": "/dhis-web-interpretation",
+            "defaultAction": "../dhis-web-interpretation/index.action",
+            "displayName": "Interpretations",
+            "icon": "../icons/dhis-web-interpretation.png",
+            "description": ""
+        },
+        {
+            "name": "dhis-web-importexport",
+            "namespace": "/dhis-web-importexport",
+            "defaultAction": "../dhis-web-importexport/index.action",
+            "displayName": "Import/Export",
+            "icon": "../icons/dhis-web-importexport.png",
+            "description": ""
+        },
+        {
+            "name": "WHO Metadata browser",
+            "namespace": "WHO Metadata browser",
+            "defaultAction": "https://play.dhis2.org/2.32.0/api/apps/WHO-Metadata-browser/index.html",
+            "displayName": "",
+            "icon": "https://play.dhis2.org/2.32.0/api/apps/WHO-Metadata-browser/icons/medicine-48.png",
+            "description": ""
+        },
+        {
+            "name": "Dashboard Classic",
+            "namespace": "Dashboard Classic",
+            "defaultAction": "https://play.dhis2.org/2.32.0/api/apps/Dashboard-Classic/index.html",
+            "displayName": "",
+            "icon": "https://play.dhis2.org/2.32.0/api/apps/Dashboard-Classic/icon.png",
+            "description": "DHIS2 Legacy Dashboard App"
+        }
+    ]
+}

--- a/cypress/fixtures/HeaderBar/getModulesWithSpecialChars.json
+++ b/cypress/fixtures/HeaderBar/getModulesWithSpecialChars.json
@@ -202,9 +202,9 @@
             "description": ""
         },
         {
-            "name": "dhis-web-importexport",
-            "namespace": "/dhis-web-importexport",
-            "defaultAction": "../dhis-web-importexport/index.action",
+            "name": "dhis-web-import-export",
+            "namespace": "/dhis-web-import-export",
+            "defaultAction": "../dhis-web-import-export/index.action",
             "displayName": "Import/Export",
             "icon": "../icons/dhis-web-importexport.png",
             "description": ""
@@ -212,17 +212,17 @@
         {
             "name": "WHO Metadata browser",
             "namespace": "WHO Metadata browser",
-            "defaultAction": "https://play.dhis2.org/2.32.0/api/apps/WHO-Metadata-browser/index.html",
+            "defaultAction": "https://debug.dhis2.org/dev/api/apps/WHO-Metadata-browser/index.html",
             "displayName": "",
-            "icon": "https://play.dhis2.org/2.32.0/api/apps/WHO-Metadata-browser/icons/medicine-48.png",
+            "icon": "https://debug.dhis2.org/dev/api/apps/WHO-Metadata-browser/icons/medicine-48.png",
             "description": ""
         },
         {
             "name": "Dashboard Classic",
             "namespace": "Dashboard Classic",
-            "defaultAction": "https://play.dhis2.org/2.32.0/api/apps/Dashboard-Classic/index.html",
+            "defaultAction": "https://debug.dhis2.org/dev/api/apps/Dashboard-Classic/index.html",
             "displayName": "",
-            "icon": "https://play.dhis2.org/2.32.0/api/apps/Dashboard-Classic/icon.png",
+            "icon": "https://debug.dhis2.org/dev/api/apps/Dashboard-Classic/icon.png",
             "description": "DHIS2 Legacy Dashboard App"
         }
     ]

--- a/cypress/integration/HeaderBar/The_HeaderBar_contains_a_menu_to_all_apps/The_user_will_be_offered_a_menu_with_5_apps.js
+++ b/cypress/integration/HeaderBar/The_HeaderBar_contains_a_menu_to_all_apps/The_user_will_be_offered_a_menu_with_5_apps.js
@@ -1,10 +1,10 @@
-import '../common/index.js'
+import { webCommons } from '../common/index.js'
 import { When, Then, Given } from 'cypress-cucumber-preprocessor/steps'
 
 Given('there are 5 apps available to the user', () => {
     cy.get('@modulesFixture').then(fx => {
         cy.route({
-            url: 'https://domain.tld/dhis-web-commons/menu/getModules.action',
+            url: `${webCommons}menu/getModules.action`,
             response: {
                 ...fx,
                 modules: fx.modules.slice(0, 5),

--- a/cypress/integration/HeaderBar/The_HeaderBar_contains_a_menu_to_all_apps/The_user_will_be_offered_a_menu_with_5_apps.js
+++ b/cypress/integration/HeaderBar/The_HeaderBar_contains_a_menu_to_all_apps/The_user_will_be_offered_a_menu_with_5_apps.js
@@ -2,12 +2,15 @@ import '../common/index.js'
 import { When, Then, Given } from 'cypress-cucumber-preprocessor/steps'
 
 Given('there are 5 apps available to the user', () => {
-    cy.fixture('HeaderBar/getModules')
-        .then(response => ({
-            ...response,
-            modules: response.modules.slice(0, 5),
-        }))
-        .as('modulesFixture')
+    cy.get('@modulesFixture').then(fx => {
+        cy.route({
+            url: 'https://domain.tld/dhis-web-commons/menu/getModules.action',
+            response: {
+                ...fx,
+                modules: fx.modules.slice(0, 5),
+            },
+        }).as('modules')
+    })
 })
 
 When('the user clicks on the menu icons', () => {

--- a/cypress/integration/HeaderBar/The_HeaderBar_should_display_the_title_provided_by_the_backend_and_the_app/The_HeaderBar_displays_the_custom_title.js
+++ b/cypress/integration/HeaderBar/The_HeaderBar_should_display_the_title_provided_by_the_backend_and_the_app/The_HeaderBar_displays_the_custom_title.js
@@ -4,12 +4,12 @@ import { Then, Given } from 'cypress-cucumber-preprocessor/steps'
 Given(
     'the custom title is {string} and the app title is "Example!"',
     applicationTitle => {
-        cy.fixture('HeaderBar/applicationTitle')
-            .then(response => ({
-                ...response,
-                applicationTitle,
-            }))
-            .as('applicationTitleFixture')
+        cy.get('@applicationTitleFixture').then(fx => {
+            cy.route({
+                url: 'https://domain.tld/api/system/info',
+                response: { ...fx, applicationTitle },
+            }).as('modules')
+        })
     }
 )
 

--- a/cypress/integration/HeaderBar/The_HeaderBar_should_display_the_title_provided_by_the_backend_and_the_app/The_HeaderBar_displays_the_custom_title.js
+++ b/cypress/integration/HeaderBar/The_HeaderBar_should_display_the_title_provided_by_the_backend_and_the_app/The_HeaderBar_displays_the_custom_title.js
@@ -1,4 +1,4 @@
-import '../common/index'
+import { baseUrl } from '../common/index'
 import { Then, Given } from 'cypress-cucumber-preprocessor/steps'
 
 Given(
@@ -6,9 +6,9 @@ Given(
     applicationTitle => {
         cy.get('@applicationTitleFixture').then(fx => {
             cy.route({
-                url: 'https://domain.tld/api/system/info',
+                url: `${baseUrl}api/systemSettings/applicationTitle`,
                 response: { ...fx, applicationTitle },
-            }).as('modules')
+            }).as('applicationTitle')
         })
     }
 )

--- a/cypress/integration/HeaderBar/The_search_should_escape_regexp_character.feature
+++ b/cypress/integration/HeaderBar/The_search_should_escape_regexp_character.feature
@@ -1,0 +1,49 @@
+Feature: The search should escape regexp characters
+
+    Scenario Outline: The user searches for an app with a regex character
+        Given some app names contain a <char>
+        And the HeaderBar loads without an error
+        And the search contains a <char>
+        Then only apps with <char> in their name should be shown
+
+        Examples:
+            | char |
+            | /    |
+            | (    |
+            | )    |
+            | [    |
+            | ]    |
+            | {    |
+            | }    |
+            | *    |
+            | +    |
+            | ?    |
+            | .    |
+            | ^    |
+            | $    |
+            | \|   |
+            | \\   |
+
+    Scenario Outline: The modules do not contain items with special chars
+        Given the HeaderBar loads without an error
+        And the search contains a <char>
+        And no app name contains a <char>
+        Then no results should be shown
+
+        Examples:
+            | char |
+            | /    |
+            | (    |
+            | )    |
+            | [    |
+            | ]    |
+            | {    |
+            | }    |
+            | *    |
+            | +    |
+            | ?    |
+            | .    |
+            | ^    |
+            | $    |
+            | \|   |
+            | \\   |

--- a/cypress/integration/HeaderBar/The_search_should_escape_regexp_character/The_modules_do_not_contain_items_with_special_chars.js
+++ b/cypress/integration/HeaderBar/The_search_should_escape_regexp_character/The_modules_do_not_contain_items_with_special_chars.js
@@ -1,0 +1,20 @@
+import '../common/index'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given(/no app name contains a (.*)/, character => {
+    cy.wrap(character).then(char => {
+        cy.get('@modulesFixture').then(fx => {
+            const modulesWithSpecialChar = fx.modules.filter(module => {
+                return module.displayName.indexOf(char) !== -1
+            })
+
+            expect(modulesWithSpecialChar).to.have.length(0)
+        })
+    })
+})
+
+Then('no results should be shown', () => {
+    cy.get('[data-test="headerbar-apps-menu-list"] > a > div').should(
+        'not.exist'
+    )
+})

--- a/cypress/integration/HeaderBar/The_search_should_escape_regexp_character/The_user_searches_for_an_app_with_a_regex_character.js
+++ b/cypress/integration/HeaderBar/The_search_should_escape_regexp_character/The_user_searches_for_an_app_with_a_regex_character.js
@@ -1,0 +1,37 @@
+import '../common/index'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given(/some app names contain a (.*)/, character => {
+    // use fixture with special chars
+    cy.fixture('HeaderBar/getModulesWithSpecialChars').as('modulesFixture')
+
+    // set fixture as response of the modules action endpoint
+    cy.get('@modulesFixture').then(fx => {
+        cy.route({
+            url: 'https://domain.tld/dhis-web-commons/menu/getModules.action',
+            response: fx,
+        }).as('modules')
+    })
+
+    // verify that there's a module with the special char in its name
+    cy.wrap(character).then(char => {
+        cy.get('@modulesFixture').then(fx => {
+            const modulesWithSpecialChar = fx.modules.filter(module => {
+                return module.displayName.indexOf(char) !== -1
+            })
+
+            expect(modulesWithSpecialChar).to.have.length.of.at.least(1)
+        })
+    })
+})
+
+Then(/only apps with (.*) in their name should be shown/, character => {
+    cy.get('[data-test="headerbar-apps-menu-list"] > a > div').should(
+        $modules => {
+            $modules.each((index, module) => {
+                const displayName = Cypress.$(module).text()
+                expect(displayName.indexOf(character)).to.not.eql(-1)
+            })
+        }
+    )
+})

--- a/cypress/integration/HeaderBar/The_search_should_escape_regexp_character/common.js
+++ b/cypress/integration/HeaderBar/The_search_should_escape_regexp_character/common.js
@@ -1,0 +1,6 @@
+import { Given } from 'cypress-cucumber-preprocessor/steps'
+
+Given(/the search contains a (.*)/, character => {
+    cy.get('[data-test="headerbar-apps-icon"]').click()
+    cy.get('#filter').type(character)
+})

--- a/cypress/integration/HeaderBar/common/index.js
+++ b/cypress/integration/HeaderBar/common/index.js
@@ -30,9 +30,7 @@ Before(() => {
     cy.fixture('HeaderBar/getModules').as('modulesFixture')
     cy.fixture('HeaderBar/dashboard').as('dashboardFixture')
     cy.fixture('HeaderBar/logo_banner').as('logoFixture')
-})
 
-Given('the HeaderBar loads without an error', () => {
     cy.server()
 
     cy.get('@applicationTitleFixture').then(fx => {
@@ -69,6 +67,8 @@ Given('the HeaderBar loads without an error', () => {
             response: fx,
         }).as('logo_banner')
     })
+})
 
+Given('the HeaderBar loads without an error', () => {
     cy.visitStory('HeaderBarTesting', 'Default')
 })

--- a/cypress/integration/HeaderBar/common/index.js
+++ b/cypress/integration/HeaderBar/common/index.js
@@ -1,6 +1,7 @@
 import { Before, Given } from 'cypress-cucumber-preprocessor/steps'
 
 export const baseUrl = 'https://domain.tld/'
+export const webCommons = 'https://domain.tld/dhis-web-commons/'
 
 /**
  * Will be executed before any `Given` statement,

--- a/src/HeaderBar/Apps.js
+++ b/src/HeaderBar/Apps.js
@@ -167,14 +167,27 @@ Item.propTypes = {
     path: propTypes.string,
 }
 
+/**
+ * Copied from here:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+ */
+function escapeRegExpCharacters(text) {
+    return text.replace(/[/.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function List({ apps, filter }) {
     return (
         <div data-test="headerbar-apps-menu-list">
             {apps
                 .filter(({ displayName, name }) => {
                     const appName = displayName || name
+                    const formattedAppName = appName.toLowerCase()
+                    const formattedFilter = escapeRegExpCharacters(
+                        filter
+                    ).toLowerCase()
+
                     return filter.length > 0
-                        ? appName.toLowerCase().match(filter.toLowerCase())
+                        ? formattedAppName.match(formattedFilter)
                         : true
                 })
                 .map(({ displayName, name, defaultAction, icon }, idx) => (


### PR DESCRIPTION
Fixes DHIS2-8809

This PR
* escapes the regex special characters in the search
* add tests for regex special characters
* slightly changes the test setup in the HeaderBar's cypress test `common/index.js` code
* changes the way to overwrite a stubbed endpoint's response slightly