### PR TITLE
docs: add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> # :warning: dhis2/ui-widgets has moved to [dhis2/ui](https://github.com/dhis2/ui)
+>
+> The package name (@dhis2/ui-widgets) is still available, and will be published from [dhis2/ui](https://github.com/dhis2/ui).
+
+---
+
 # ui-widgets
 
 ![DHIS2](https://github.com/dhis2/ui-widgets/workflows/DHIS2/badge.svg)[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)


### PR DESCRIPTION
Follow up task after merging this PR would be:
- Apply this project description: [DEPRECATED] Please refer to https://github.com/dhis2/ui
- Archive this repo 